### PR TITLE
Add AGI investment income exclusion

### DIFF
--- a/openfisca_us/tests/policy/baseline/finance/tax/invinc_ec_base.yaml
+++ b/openfisca_us/tests/policy/baseline/finance/tax/invinc_ec_base.yaml
@@ -1,0 +1,12 @@
+- name: All inputs used
+  period: 2020
+  input:
+    sep: 1
+    filer_p22250: 1
+    filer_p23250: 1
+    filer_e00300: 1
+    filer_e00600: 1
+    filer_e01100: 1
+    filer_e01200: 1
+  output:
+    invinc_ec_base: 6

--- a/openfisca_us/variables/finance/tax/outputs.py
+++ b/openfisca_us/variables/finance/tax/outputs.py
@@ -1004,24 +1004,17 @@ class invinc_ec_base(Variable):
     documentation = """Exclusion of investment income from AGI"""
 
     def formula(tax_unit, period, parameters):
-        # Limitatition on net short-term and
+        # Limitation on net short-term and
         # long-term capital losses
         limited_capital_gain = max_(
             -3000.0 / tax_unit("sep", period),
             add(tax_unit, period, "filer_p22250", "filer_p23250"),
         )
+        OTHER_INV_INCOME_VARS = ["e00300", "e00600", "e01100", "e01200"]
         other_inv_income = add(
             tax_unit,
             period,
-            *[
-                "filer_" + variable
-                for variable in (
-                    "e00300",
-                    "e00600",
-                    "e01100",
-                    "e01200",
-                )
-            ],
+            *["filer_" + variable for variable in OTHER_INV_INCOME_VARS],
         )
         return limited_capital_gain + other_inv_income
 

--- a/openfisca_us/variables/finance/tax/outputs.py
+++ b/openfisca_us/variables/finance/tax/outputs.py
@@ -302,6 +302,7 @@ class sep(Variable):
     value_type = int
     entity = TaxUnit
     definition_period = YEAR
+    default_value = 1
     documentation = (
         """2 when MARS is 3 (married filing separately); otherwise 1"""
     )
@@ -998,9 +999,31 @@ class invinc_ec_base(Variable):
     value_type = float
     entity = TaxUnit
     definition_period = YEAR
-    documentation = (
-        """search taxcalc/calcfunctions.py for how calculated and used"""
-    )
+    label = "AGI investment income exclusion"
+    unit = "currency-USD"
+    documentation = """Exclusion of investment income from AGI"""
+
+    def formula(tax_unit, period, parameters):
+        # Limitatition on net short-term and
+        # long-term capital losses
+        limited_capital_gain = max_(
+            -3000.0 / tax_unit("sep", period),
+            add(tax_unit, period, "filer_p22250", "filer_p23250"),
+        )
+        other_inv_income = add(
+            tax_unit,
+            period,
+            *[
+                "filer_" + variable
+                for variable in (
+                    "e00300",
+                    "e00600",
+                    "e01100",
+                    "e01200",
+                )
+            ],
+        )
+        return limited_capital_gain + other_inv_income
 
 
 class pre_c04600(Variable):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.1.0",
+    version="0.1.1",
     author="Nikhil Woodruff",
     author_email="nikhil.woodruff@ubicenter.org",
     classifiers=[


### PR DESCRIPTION
Adds the logic and a test for `invinc_ec_base` from the `taxcalc` [source](https://github1s.com/pslmodels/tax-calculator/blob/HEAD/taxcalc/calcfunctions.py#L401).