### PR TITLE
Add core income definitions

### DIFF
--- a/.vscode/python.code-snippets
+++ b/.vscode/python.code-snippets
@@ -18,8 +18,10 @@
 		 		"class ${1:name}(Variable):",
 				"	value_type = ${2:float}",
 				"	entity = ${3:TaxUnit}",
-				"	label = u\"${4:Label}\"",
-				"	definition_period = ${5:YEAR}",
+				"	label = \"${4:Label}\"",
+				"	unit = \"${5:currency-USD}\"",
+				"	documentation = \"${6:Description}\"",
+				"	definition_period = ${7:YEAR}",
 				"",
 				""
 		 	],
@@ -43,7 +45,7 @@
 				"	definition_period = ${3:YEAR}",
 				"",
 				"	def formula(tax_unit, period, parameters):",
-				"		return tax_unit_non_dep_sum(${1:name}, tax_unit, period)",
+				"		return tax_unit_non_dep_sum(\"${1:name}\", tax_unit, period)",
 			]
 	}
 }

--- a/openfisca_us/variables/finance/income/person.py
+++ b/openfisca_us/variables/finance/income/person.py
@@ -3,13 +3,46 @@ from openfisca_us.entities import *
 from openfisca_us.tools.general import *
 
 
+class market_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Market income"
+    unit = "currency-USD"
+    documentation = "Income from non-benefit sources"
+    definition_period = YEAR
+
+
+class gross_income(Variable):
+    value_type = float
+    entity = Person
+    label = "Gross income"
+    unit = "currency-USD"
+    documentation = "Combined market and benefit income"
+    definition_period = YEAR
+
+
+class tax(Variable):
+    value_type = float
+    entity = Person
+    label = "Tax"
+    unit = "currency-USD"
+    documentation = "Total tax liability"
+    definition_period = YEAR
+
+
+class benefits(Variable):
+    value_type = float
+    entity = Person
+    label = "Benefits"
+    unit = "currency-USD"
+    documentation = "Total benefit entitlement"
+    definition_period = YEAR
+
+
 class net_income(Variable):
     value_type = float
     entity = Person
-    label = u"Net income"
+    label = "Net income"
+    unit = "currency-USD"
+    documentation = "Disposable income after taxes and transfers"
     definition_period = YEAR
-
-    def formula(person, period, parameters):
-        return person("is_spm_unit_head", period) * person.spm_unit(
-            "spm_unit_net_income", period
-        )


### PR DESCRIPTION
Somewhat ironically, the first PR filed after #281 doesn't fit in any of the options. This PR adds a few variables for our core income definitions, with the idea that when we're working on new programs that use income definitions, we should either use the core variables (mapped to the appropriate entity) or create program-specific income definitions. I've also added `unit` and `documentation` to the VS Code variable snippet.