### PR TITLE
Add ItemDedCap

### DIFF
--- a/openfisca_us/tests/policy/baseline/finance/tax/c18300.yaml
+++ b/openfisca_us/tests/policy/baseline/finance/tax/c18300.yaml
@@ -8,13 +8,13 @@
   period: 2017
   absolute_error_margin: 0
   input:
-    e18400_capped: 20_000
+    filer_e18400: 20_000
   output:
     c18300: 20_000
 - name: Capped after 2018
   period: 2020
   absolute_error_margin: 0
   input:
-    e18400_capped: 20_000
+    filer_e18400: 20_000
   output:
     c18300: 10_000

--- a/openfisca_us/variables/finance/tax/inputs.py
+++ b/openfisca_us/variables/finance/tax/inputs.py
@@ -682,6 +682,7 @@ class e17500(Variable):
     definition_period = YEAR
     documentation = """Itemizable medical and dental expenses.  WARNING: this variable is zero below the floor in PUF data."""
 
+
 class filer_e17500(Variable):
     value_type = float
     entity = TaxUnit
@@ -697,6 +698,7 @@ class e18400(Variable):
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable state and local income/sales taxes"""
+
 
 class filer_e18400(Variable):
     value_type = float
@@ -714,6 +716,7 @@ class e18500(Variable):
     definition_period = YEAR
     documentation = """Itemizable real-estate taxes paid"""
 
+
 class filer_e18500(Variable):
     value_type = float
     entity = TaxUnit
@@ -729,6 +732,7 @@ class e19200(Variable):
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable interest paid"""
+
 
 class filer_e19200(Variable):
     value_type = float
@@ -746,6 +750,7 @@ class e19800(Variable):
     definition_period = YEAR
     documentation = """Itemizable charitable giving: cash/check contributions.  WARNING: this variable is already capped in PUF data."""
 
+
 class filer_e19800(Variable):
     value_type = float
     entity = TaxUnit
@@ -755,26 +760,32 @@ class filer_e19800(Variable):
     def formula(tax_unit, period, parameters):
         return tax_unit_non_dep_sum("e19800", tax_unit, period)
 
+
 class e20100(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable charitable giving: other than cash/check contributions.  WARNING: this variable is already capped in PUF data."""
 
+
 class filer_e20100(Variable):
     value_type = float
     entity = TaxUnit
-    label = u"Itemized non-cash charity for the tax unit (excluding dependents)"
+    label = (
+        u"Itemized non-cash charity for the tax unit (excluding dependents)"
+    )
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
         return tax_unit_non_dep_sum("e20100", tax_unit, period)
+
 
 class e20400(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable miscellaneous deductions.  WARNING: this variable is zero below the floor in PUF data."""
+
 
 class filer_e20400(Variable):
     value_type = float
@@ -785,11 +796,13 @@ class filer_e20400(Variable):
     def formula(tax_unit, period, parameters):
         return tax_unit_non_dep_sum("e20400", tax_unit, period)
 
+
 class g20500(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable gross (before 10% AGI disregard) casualty or theft loss"""
+
 
 class filer_g20500(Variable):
     value_type = float

--- a/openfisca_us/variables/finance/tax/inputs.py
+++ b/openfisca_us/variables/finance/tax/inputs.py
@@ -682,12 +682,30 @@ class e17500(Variable):
     definition_period = YEAR
     documentation = """Itemizable medical and dental expenses.  WARNING: this variable is zero below the floor in PUF data."""
 
+class filer_e17500(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized medical and dental expenses for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e17500", tax_unit, period)
+
 
 class e18400(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable state and local income/sales taxes"""
+
+class filer_e18400(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized SALT for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e18400", tax_unit, period)
 
 
 class e18500(Variable):
@@ -696,12 +714,30 @@ class e18500(Variable):
     definition_period = YEAR
     documentation = """Itemizable real-estate taxes paid"""
 
+class filer_e18500(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized real estate for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e18500", tax_unit, period)
+
 
 class e19200(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable interest paid"""
+
+class filer_e19200(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemizable interest paid for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e19200", tax_unit, period)
 
 
 class e19800(Variable):
@@ -710,6 +746,14 @@ class e19800(Variable):
     definition_period = YEAR
     documentation = """Itemizable charitable giving: cash/check contributions.  WARNING: this variable is already capped in PUF data."""
 
+class filer_e19800(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized charity for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e19800", tax_unit, period)
 
 class e20100(Variable):
     value_type = float
@@ -717,6 +761,14 @@ class e20100(Variable):
     definition_period = YEAR
     documentation = """Itemizable charitable giving: other than cash/check contributions.  WARNING: this variable is already capped in PUF data."""
 
+class filer_e20100(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized non-cash charity for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e20100", tax_unit, period)
 
 class e20400(Variable):
     value_type = float
@@ -724,12 +776,29 @@ class e20400(Variable):
     definition_period = YEAR
     documentation = """Itemizable miscellaneous deductions.  WARNING: this variable is zero below the floor in PUF data."""
 
+class filer_e20400(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized misc. for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("e20400", tax_unit, period)
 
 class g20500(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
     documentation = """Itemizable gross (before 10% AGI disregard) casualty or theft loss"""
+
+class filer_g20500(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Itemized casualty loss for the tax unit (excluding dependents)"
+    definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit_non_dep_sum("g20500", tax_unit, period)
 
 
 class e24515(Variable):

--- a/openfisca_us/variables/finance/tax/outputs.py
+++ b/openfisca_us/variables/finance/tax/outputs.py
@@ -856,17 +856,8 @@ class c17000(Variable):
         )
         return max_(
             0,
-            tax_unit("e17500_capped", period) - medical_floor,
+            tax_unit("filer_e17500", period) - medical_floor,
         )
-
-
-class e17500_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = (
-        """Sch A: Medical expenses, capped as a decimal fraction of AGI"""
-    )
 
 
 class c18300(Variable):
@@ -878,25 +869,11 @@ class c18300(Variable):
     documentation = """Sch A: State and local taxes plus real estate taxes deducted (component of pre-limitation c21060 total)"""
 
     def formula(tax_unit, period, parameters):
-        c18400 = max_(tax_unit("e18400_capped", period), 0)
-        c18500 = tax_unit("e18500_capped", period)
+        c18400 = max_(tax_unit("filer_e18400", period), 0)
+        c18500 = tax_unit("filer_e18500", period)
         salt = parameters(period).tax.deductions.itemized.salt_and_real_estate
         cap = salt.cap[tax_unit("mars", period)]
         return min_(c18400 + c18500, cap)
-
-
-class e18400_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: State and local income taxes deductible, capped as a decimal fraction of AGI"""
-
-
-class e18500_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: State and local real estate taxes deductible, capped as a decimal fraction of AGI"""
 
 
 class c19200(Variable):
@@ -908,14 +885,7 @@ class c19200(Variable):
     documentation = """Sch A: Interest deducted (component of pre-limitation c21060 total)"""
 
     def formula(tax_unit, period, parameters):
-        return tax_unit("e19200_capped", period)
-
-
-class e19200_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: Interest deduction deductible, capped as a decimal fraction of AGI"""
+        return tax_unit("filer_e19200", period)
 
 
 class c19700(Variable):
@@ -931,27 +901,13 @@ class c19700(Variable):
         posagi = tax_unit("posagi", period)
         lim30 = min_(
             charity.ceiling.non_cash * posagi,
-            tax_unit("e20100_capped", period),
+            tax_unit("filer_e20100", period),
         )
         c19700 = min_(
             charity.ceiling.all * posagi,
-            lim30 + tax_unit("e19800_capped", period),
+            lim30 + tax_unit("filer_e19800", period),
         )
         return max_(c19700, 0)
-
-
-class e19800_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: Charity cash contributions deductible, capped as a decimal fraction of AGI"""
-
-
-class e20100_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: Charity noncash contributions deductible, capped as a decimal fraction of AGI"""
 
 
 class c20500(Variable):
@@ -965,15 +921,8 @@ class c20500(Variable):
     def formula(tax_unit, period, parameters):
         casualty = parameters(period).tax.deductions.itemized.casualty
         floor = casualty.floor * tax_unit("posagi", period)
-        deduction = max_(0, tax_unit("g20500_capped", period) - floor)
+        deduction = max_(0, tax_unit("filer_g20500", period) - floor)
         return deduction * (1 - casualty.haircut)
-
-
-class g20500_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: Gross casualty or theft loss deductible, capped as a decimal fraction of AGI"""
 
 
 class c20800(Variable):
@@ -987,15 +936,8 @@ class c20800(Variable):
     def formula(tax_unit, period, parameters):
         misc = parameters(period).tax.deductions.itemized.misc
         floor = misc.floor * tax_unit("posagi", period)
-        deduction = max_(0, tax_unit("e20400_capped", period) - floor)
+        deduction = max_(0, tax_unit("filer_e20400", period) - floor)
         return deduction * (1 - misc.haircut)
-
-
-class e20400_capped(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-    documentation = """Sch A: Gross miscellaneous deductions deductible, capped as a decimal fraction of AGI"""
 
 
 class c21040(Variable):


### PR DESCRIPTION
This essentially skips the functionality of `ItemDedCap` in tax-calc, given that it has no effect in the baseline policy. `*_capped` variables have been reduced to their `filer_*` equivalents - the alternative would have been to add an extra capped variable which is always a copy - this seems unnecessary now, even with future tax-calc parity checking.