### PR TITLE
Add metadata for PolicyEngine US

### DIFF
--- a/openfisca_us/variables/irs/inputs.py
+++ b/openfisca_us/variables/irs/inputs.py
@@ -42,10 +42,11 @@ class mars(Variable):
     label = "MARS Status for the tax unit"
 
     def formula(tax_unit, period, parameters):
-        return tax_unit.max(
+        has_spouse = tax_unit.max(
             tax_unit.members("is_tax_unit_spouse", period)
-            * tax_unit.members("age", period)
+            * (tax_unit.members("age", period) > 0)
         )
+        return where(has_spouse, MARSType.JOINT, MARSType.SINGLE)
 
 
 class midr(Variable):

--- a/openfisca_us/variables/irs/inputs.py
+++ b/openfisca_us/variables/irs/inputs.py
@@ -39,7 +39,7 @@ class mars(Variable):
     possible_values = MARSType
     default_value = MARSType.SINGLE
     definition_period = YEAR
-    label = "MARS Status for the tax unit"
+    label = "Marital status for the tax unit"
 
     def formula(tax_unit, period, parameters):
         has_spouse = tax_unit.max(

--- a/openfisca_us/variables/usda/school_meals.py
+++ b/openfisca_us/variables/usda/school_meals.py
@@ -55,7 +55,9 @@ class school_meal_subsidy(Variable):
     value_type = float
     entity = SPMUnit
     definition_period = YEAR
-    documentation = ""
+    label = "School meal subsidy"
+    unit = "currency-GBP"
+    documentation = "Total school meal subsidy entitlement"
 
     def formula(spm_unit, period, parameters):
         # Get state group and tier (based on poverty ratio) for SPM unit.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.1.1",
+    version="0.1.2",
     author="Nikhil Woodruff",
     author_email="nikhil.woodruff@ubicenter.org",
     classifiers=[


### PR DESCRIPTION
These are just a few fixes for a functional household page on PolicyEngine.
* Added a label, unit and documentation field for `school_meal_subsidy`
* Fixed the MARS formula (for now, just calculating SINGLE/JOINT status - we can add more logic later).