### PR TITLE
Add Lifeline benefit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-# 0.0.1
+## 0.0.1
 
 * First prototype version with a standard deduction variable
+
+## 0.3.0
+
+* Add Lifeline benefit

--- a/openfisca_us/parameters/fcc/lifeline/amount.yaml
+++ b/openfisca_us/parameters/fcc/lifeline/amount.yaml
@@ -1,9 +1,9 @@
-description: Maximum percent of the poverty line to be eligible for Lifeline
+description: Maximum Lifeline benefit amount
 values:
-  2016-12-01: 1.35
+  2016-12-01: 9.25
 metadata:
   period: month
-  unit: /1
+  unit: currency-USD
   reference:
     - title: 47 CFR § 54.409 - Consumer qualification for Lifeline.
       href: https://www.law.cornell.edu/cfr/text/47/54.409

--- a/openfisca_us/parameters/fcc/lifeline/amount.yaml
+++ b/openfisca_us/parameters/fcc/lifeline/amount.yaml
@@ -1,11 +1,11 @@
 description: Maximum Lifeline benefit amount
 values:
-  2016-12-01: 9.25
+  2012-04-02: 9.25
 metadata:
   period: month
   unit: currency-USD
   reference:
-    - title: 47 CFR § 54.409 - Consumer qualification for Lifeline.
-      href: https://www.law.cornell.edu/cfr/text/47/54.409
-    - title: Lifeline Program for Low-Income Consumers # Specifies 2016-12-01 start date.
-      href: https://www.fcc.gov/general/lifeline-program-low-income-consumers
+    - title: 47 CFR § 54.403 - Lifeline support amount.
+      href: https://www.law.cornell.edu/cfr/text/47/54.403
+    - title: 77 FR 12967
+      href: https://www.govinfo.gov/content/pkg/FR-2012-03-02/pdf/2012-4978.pdf#page=17

--- a/openfisca_us/parameters/fcc/lifeline/categorical_eligibility.yaml
+++ b/openfisca_us/parameters/fcc/lifeline/categorical_eligibility.yaml
@@ -1,0 +1,21 @@
+description: Program participation that entitles a household to the Lifeline program
+values:
+  2016-12-01:
+    - medicaid
+    - snap
+    - ssi
+    # Also not implemented:
+    # - Federal Public Housing Assistance
+    # - Veterans and Survivors Pension Benefit
+    # - Tribal programs:
+    #   - Bureau of Indian Affairs general assistance
+    #   - Tribally administered Temporary Assistance for Needy Families
+    #   - Head Start (only those households meeting its income qualifying standard)
+    #   - Food Distribution Program on Indian Reservations
+metadata:
+  period: month
+  reference:
+    - title: 47 CFR § 54.409 - Consumer qualification for Lifeline.
+      href: https://www.law.cornell.edu/cfr/text/47/54.409
+    - title: Lifeline Program for Low-Income Consumers # Specifies 2016-12-01 start date.
+      href: https://www.fcc.gov/general/lifeline-program-low-income-consumers

--- a/openfisca_us/parameters/fcc/lifeline/fpg_limit.yaml
+++ b/openfisca_us/parameters/fcc/lifeline/fpg_limit.yaml
@@ -1,4 +1,4 @@
-description: Maximum percent of the poverty line to be eligible for Lifeline
+description: Maximum percent of the federal poverty guideline to be eligible for Lifeline
 values:
   2016-12-01: 1.35
 metadata:

--- a/openfisca_us/parameters/fcc/lifeline/fpl_limit.yaml
+++ b/openfisca_us/parameters/fcc/lifeline/fpl_limit.yaml
@@ -1,0 +1,10 @@
+description: Maximum percent of the poverty line to be eligible for Lifeline
+  2016-12-01: 1.35
+metadata:
+  period: month
+  unit: /1
+  reference:
+    - title: 47 CFR § 54.409 - Consumer qualification for Lifeline.
+      href: https://www.law.cornell.edu/cfr/text/47/54.409
+    - title: Lifeline Program for Low-Income Consumers # Specifies 2016-12-01 start date.
+      href: https://www.fcc.gov/general/lifeline-program-low-income-consumers

--- a/openfisca_us/tests/policy/baseline/fcc/fcc_fpg_ratio.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/fcc_fpg_ratio.yaml
@@ -1,0 +1,35 @@
+- name: Default family has no income and nonzero federal poverty guideline
+  period: 2022
+  absolute_error_margin: 0.01
+  output:
+    fcc_fpg_ratio: 0
+
+- name: Single person with $100 income and $200 FPG
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    people:
+      person:
+        irs_gross_income: 100
+    spm_units:
+      spm_unit:
+        spm_fpg: 200
+        members: [person]
+  output:
+    fcc_fpg_ratio: 0.5
+
+- name: Couple with $300 income and $100 FPG
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    people:
+      p1:
+        irs_gross_income: 100
+      p2:
+        irs_gross_income: 200
+    spm_units:
+      spm_unit:
+        spm_fpg: 100
+        members: [p1, p2]
+  output:
+    fcc_fpg_ratio: 3

--- a/openfisca_us/tests/policy/baseline/fcc/fcc_fpg_ratio.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/fcc_fpg_ratio.yaml
@@ -13,7 +13,7 @@
         irs_gross_income: 100
     spm_units:
       spm_unit:
-        spm_fpg: 200
+        spm_unit_fpg: 200
         members: [person]
   output:
     fcc_fpg_ratio: 0.5
@@ -29,7 +29,7 @@
         irs_gross_income: 200
     spm_units:
       spm_unit:
-        spm_fpg: 100
+        spm_unit_fpg: 100
         members: [p1, p2]
   output:
     fcc_fpg_ratio: 3

--- a/openfisca_us/tests/policy/baseline/fcc/lifeline/integration.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/lifeline/integration.yaml
@@ -1,0 +1,9 @@
+- name: Individual who doesn't get SNAP but is below the poverty line and has phone cost can get full Lifeline benefit.
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    phone_cost: 20 * 12
+    snap: 0
+    irs_gross_income: 10_000 # Below the poverty line for one person.
+  output:
+    lifeline: 9.25 * 12

--- a/openfisca_us/tests/policy/baseline/fcc/lifeline/is_lifeline_eligible.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/lifeline/is_lifeline_eligible.yaml
@@ -1,0 +1,22 @@
+- name: Default family qualifies because of low income
+  period: 2022
+  absolute_error_margin: 0.01
+  output:
+    is_lifeline_eligible: true
+
+- name: Family with income >135% of FPG is ineligible
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    fcc_fpg_ratio: 1.5
+  output:
+    is_lifeline_eligible: false
+
+- name: Family with income >135% of FPG that participates in SNAP is eligible
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    fcc_fpg_ratio: 1.5
+    snap: 100
+  output:
+    is_lifeline_eligible: true

--- a/openfisca_us/tests/policy/baseline/fcc/lifeline/is_lifeline_eligible.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/lifeline/is_lifeline_eligible.yaml
@@ -1,14 +1,15 @@
-- name: Default family qualifies because of low income
+- name: Default family qualifies because of low income and SNAP eligibility
   period: 2022
   absolute_error_margin: 0.01
   output:
     is_lifeline_eligible: true
 
-- name: Family with income >135% of FPG is ineligible
+- name: Family with no SNAP and income >135% of FPG is ineligible
   period: 2022
   absolute_error_margin: 0.01
   input:
     fcc_fpg_ratio: 1.5
+    snap: 0
   output:
     is_lifeline_eligible: false
 

--- a/openfisca_us/tests/policy/baseline/fcc/lifeline/lifeline.yaml
+++ b/openfisca_us/tests/policy/baseline/fcc/lifeline/lifeline.yaml
@@ -1,0 +1,32 @@
+- name: Default family qualifies because of low income, but gets $0 because of $0 default broadband and phone costs.
+  period: 2022
+  absolute_error_margin: 0.01
+  output:
+    lifeline: 0
+
+- name: Default family qualifies and receives full amount if broadband cost exceeds the maximum
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    broadband_cost: 10 * 12
+  output:
+    lifeline: 9.25 * 12
+
+- name: Ineligible family with broadband cost gets $0
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    is_lifeline_eligible: false
+    broadband_cost: 10 * 12
+  output:
+    lifeline: 0
+
+- name: Eligible family with phone + broadband cost below the cap get their costs back
+  period: 2022
+  absolute_error_margin: 0.01
+  input:
+    is_lifeline_eligible: true
+    broadband_cost: 3 * 12
+    phone_cost: 5 * 12
+  output:
+    lifeline: 8 * 12

--- a/openfisca_us/variables/expense/spm_unit.py
+++ b/openfisca_us/variables/expense/spm_unit.py
@@ -62,3 +62,12 @@ class broadband_cost(Variable):
     documentation = "Broadband cost for this SPM unit"
     unit = "currency-USD"
     definition_period = YEAR
+
+
+class phone_cost(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "Phone cost"
+    documentation = "Phone line cost for this SPM unit"
+    unit = "currency-USD"
+    definition_period = YEAR

--- a/openfisca_us/variables/fcc/fcc_fpg_ratio.py
+++ b/openfisca_us/variables/fcc/fcc_fpg_ratio.py
@@ -7,6 +7,7 @@ class fcc_fpg_ratio(Variable):
     label = "SPM unit's federal poverty ratio as defined by the FCC"
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/cfr/text/47/54.400#f"
+    unit = "ratio"
 
     def formula(spm_unit, period, parameters):
         income = spm_unit.sum(spm_unit.members("irs_gross_income", period))

--- a/openfisca_us/variables/fcc/fcc_fpg_ratio.py
+++ b/openfisca_us/variables/fcc/fcc_fpg_ratio.py
@@ -1,0 +1,14 @@
+from openfisca_us.model_api import *
+
+
+class fcc_fpg_ratio(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = "SPM unit's federal poverty ratio as defined by the FCC"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/cfr/text/47/54.400#f"
+
+    def formula(spm_unit, period, parameters):
+        income = spm_unit.sum(spm_unit.members("irs_gross_income", period))
+        fpg = spm_unit("spm_unit_fpg", period)
+        return income / fpg

--- a/openfisca_us/variables/fcc/fcc_fpg_ratio.py
+++ b/openfisca_us/variables/fcc/fcc_fpg_ratio.py
@@ -4,7 +4,8 @@ from openfisca_us.model_api import *
 class fcc_fpg_ratio(Variable):
     value_type = float
     entity = SPMUnit
-    label = "SPM unit's federal poverty ratio as defined by the FCC"
+    label = "Federal poverty ratio per FCC"
+    documentation = "SPM unit's ratio of IRS gross income to their federal poverty guideline"
     definition_period = YEAR
     reference = "https://www.law.cornell.edu/cfr/text/47/54.400#f"
     unit = "ratio"

--- a/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
+++ b/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
@@ -7,3 +7,15 @@ class is_lifeline_eligible(Variable):
     label = "Eligible for Lifeline"
     documentation = "Eligible for Lifeline phone or broadband subsidy"
     definition_period = YEAR
+    reference = "https://www.law.cornell.edu/cfr/text/47/54.409"
+
+    def formula(spm_unit, period, parameters):
+        programs = parameters(period).fcc.lifeline.categorical_eligibility
+        categorically_eligible = np.any(
+            [spm_unit(program, period) for program in programs]
+        )
+        fpg_eligible = (
+            spm_unit("fcc_fpg_ratio")
+            <= parameters(period).fcc.lifeline.fpl_threshold
+        )
+        return categorically_eligible | fpg_eligible

--- a/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
+++ b/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
@@ -14,8 +14,7 @@ class is_lifeline_eligible(Variable):
         categorically_eligible = np.any(
             [spm_unit(program, period) for program in programs]
         )
-        fpg_eligible = (
-            spm_unit("fcc_fpg_ratio")
-            <= parameters(period).fcc.lifeline.fpl_threshold
-        )
+        fpg_ratio = spm_unit("fcc_fpg_ratio")
+        fpg_threshold = parameters(period).fcc.lifeline.fpg_threshold
+        fpg_eligible = fpg_ratio <= fpg_threshold
         return categorically_eligible | fpg_eligible

--- a/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
+++ b/openfisca_us/variables/fcc/lifeline/is_lifeline_eligible.py
@@ -14,7 +14,7 @@ class is_lifeline_eligible(Variable):
         categorically_eligible = np.any(
             [spm_unit(program, period) for program in programs]
         )
-        fpg_ratio = spm_unit("fcc_fpg_ratio")
-        fpg_threshold = parameters(period).fcc.lifeline.fpg_threshold
-        fpg_eligible = fpg_ratio <= fpg_threshold
+        fpg_ratio = spm_unit("fcc_fpg_ratio", period)
+        fpg_limit = parameters(period).fcc.lifeline.fpg_limit
+        fpg_eligible = fpg_ratio <= fpg_limit
         return categorically_eligible | fpg_eligible

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -1,0 +1,18 @@
+from openfisca_us.model_api import *
+
+
+class lifeline(Variable):
+    value_type = bool
+    entity = SPMUnit
+    label = "Lifeline benefit amount"
+    documentation = "Amount of Lifeline phone and broadband benefit"
+    definition_period = YEAR
+
+    def formula(spm_unit, period, parameters):
+        max_amount = parameters(period).fcc.lifeline.amount * 12
+        phone_broadband_cost = add(
+            spm_unit, period, ["phone_cost", "broadband_cost"]
+        )
+        amount_if_eligible = min_(phone_broadband_cost, max_amount)
+        eligible = spm_unit("is_lifeline_eligible", period)
+        return where(eligible, amount_if_eligible, 0)

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -8,7 +8,7 @@ class lifeline(Variable):
     documentation = "Amount of Lifeline phone and broadband benefit"
     definition_period = YEAR
     unit = "currency-USD"
-
+reference = "https://www.law.cornell.edu/cfr/text/47/54.403"
     def formula(spm_unit, period, parameters):
         max_amount = parameters(period).fcc.lifeline.amount * 12
         phone_broadband_cost = add(

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -2,7 +2,7 @@ from openfisca_us.model_api import *
 
 
 class lifeline(Variable):
-    value_type = bool
+    value_type = float
     entity = SPMUnit
     label = "Lifeline benefit amount"
     documentation = "Amount of Lifeline phone and broadband benefit"

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -11,8 +11,8 @@ class lifeline(Variable):
 
     def formula(spm_unit, period, parameters):
         max_amount = parameters(period).fcc.lifeline.amount * 12
-        phone_broadband_cost = spm_unit("phone_cost", period) + spm_unit(
-            "broadband_cost", period
+        phone_broadband_cost = add(
+            spm_unit, period, "phone_cost", "broadband_cost"
         )
         amount_if_eligible = min_(phone_broadband_cost, max_amount)
         eligible = spm_unit("is_lifeline_eligible", period)

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -8,7 +8,8 @@ class lifeline(Variable):
     documentation = "Amount of Lifeline phone and broadband benefit"
     definition_period = YEAR
     unit = "currency-USD"
-reference = "https://www.law.cornell.edu/cfr/text/47/54.403"
+    reference = "https://www.law.cornell.edu/cfr/text/47/54.403"
+
     def formula(spm_unit, period, parameters):
         max_amount = parameters(period).fcc.lifeline.amount * 12
         phone_broadband_cost = add(

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -7,6 +7,7 @@ class lifeline(Variable):
     label = "Lifeline benefit amount"
     documentation = "Amount of Lifeline phone and broadband benefit"
     definition_period = YEAR
+    unit = "currency-USD"
 
     def formula(spm_unit, period, parameters):
         max_amount = parameters(period).fcc.lifeline.amount * 12

--- a/openfisca_us/variables/fcc/lifeline/lifeline.py
+++ b/openfisca_us/variables/fcc/lifeline/lifeline.py
@@ -11,8 +11,8 @@ class lifeline(Variable):
 
     def formula(spm_unit, period, parameters):
         max_amount = parameters(period).fcc.lifeline.amount * 12
-        phone_broadband_cost = add(
-            spm_unit, period, ["phone_cost", "broadband_cost"]
+        phone_broadband_cost = spm_unit("phone_cost", period) + spm_unit(
+            "broadband_cost", period
         )
         amount_if_eligible = min_(phone_broadband_cost, max_amount)
         eligible = spm_unit("is_lifeline_eligible", period)

--- a/openfisca_us/variables/hhs/medicaid/medicaid.py
+++ b/openfisca_us/variables/hhs/medicaid/medicaid.py
@@ -1,0 +1,10 @@
+from openfisca_us.model_api import *
+
+
+class medicaid(Variable):
+    value_type = float
+    entity = SPMUnit
+    definition_period = YEAR
+    documentation = "Estimated benefit amount from Medicaid"
+    label = "Medicaid benefit"
+    unit = "currency-USD"

--- a/openfisca_us/variables/irs/irs_gross_income.py
+++ b/openfisca_us/variables/irs/irs_gross_income.py
@@ -1,0 +1,11 @@
+from openfisca_us.model_api import *
+
+
+class irs_gross_income(Variable):
+    value_type = float
+    entity = Person
+    label = "IRS gross income"
+    unit = "currency-USD"
+    documentation = "Gross income as defined in the Internal Revenue Code"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/61"

--- a/openfisca_us/variables/ssa/ssi/is_ssi_disabled.py
+++ b/openfisca_us/variables/ssa/ssi/is_ssi_disabled.py
@@ -1,6 +1,4 @@
-from openfisca_core.model_api import *
-from openfisca_us.entities import *
-from openfisca_us.tools.general import *
+from openfisca_us.model_api import *
 
 
 class is_ssi_disabled(Variable):

--- a/openfisca_us/variables/ssa/ssi/ssi.py
+++ b/openfisca_us/variables/ssa/ssi/ssi.py
@@ -1,0 +1,10 @@
+from openfisca_us.model_api import *
+
+
+class ssi(Variable):
+    value_type = float
+    entity = SPMUnit
+    definition_period = YEAR
+    documentation = "Supplemental Security Income amount"
+    label = "Supplemental Security Income"
+    unit = "currency-USD"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description="OpenFisca tax and benefit system for the US",
     keywords="benefit microsimulation social tax",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
-    url="https://github.com/nikhilwoodruff/openfisca-us",
+    url="https://github.com/PolicyEngine/openfisca-us",
     include_package_data=True,  # Will read MANIFEST.in
     data_files=[
         (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.2.0",
+    version="0.3.0",
     author="Nikhil Woodruff",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
# New variable: `lifeline`

- [x] Label field added
- [x] Documentation field added
- [x] Unit field added
- [x] Variable name follows conventions
- [x] Unit test(s) added
- [x] Integration test(s) added if relevant

## What's changed

Adds the `lifeline` variable, as well as dependents `is_lifeline_eligible` and `fcc_fpg_ratio`. These in turn depend on some other new empty variables: `phone_cost`, `medicaid`, `ssi`, and `irs_gross_income`.

Also some minor formatting changes in existing code.