### PR TITLE
Adopt keepachangelog.com standard

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -1,12 +1,12 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore LICENSE* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md CHANGELOG.md Makefile .gitignore LICENSE* .github/*"
 
-last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
+last_tagged_commit=$(git describe --tags --abbrev=0 --first-parent) # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 
-if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
-then
+if git diff-index --name-only --exit-code $last_tagged_commit -- . $(echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'); then # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
   echo "No functional changes detected."
   exit 1
-else echo "The functional files above were changed."
+else
+  echo "The functional files above were changed."
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,68 @@
 # Changelog
 
-## 0.0.1
+All notable changes to this project will be documented in this file.
 
-* First prototype version with a standard deduction variable
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### 0.3.0
+## [0.10.0] - 2021-12-28
 
-* Add Lifeline benefit
+### Added
 
-#### 0.3.1
+* Income-to-SMI (state median income) ratio.
 
-* Add automated tests
+## [0.9.0] - 2021-12-28
 
-### 0.4.0
+### Added
 
-* Broke down TANF eligibility into demographic and financial variables, with financial separated by current enrollment in program
-* Specified demographic TANF eligibility per IL rules
+* Social Security taxation logic.
 
-### 0.5.0
+## [0.8.0] - 2021-12-28
 
-* Added Medicaid Tests + Income Threshold Formula for California 
+### Added 
 
-### 0.6.0
+* Minimum benefit logic for SNAP.
 
-* Added Alternative Minimum Tax (AMT) income and liability logic
-* Added development tools for auto-generating unit tests for Tax-Calculator functions
+## [0.7.0] - 2021-12-28
 
-## 0.7.0
+### Added
 
-* Added Gains Tax (capital gains treatment) logic and parameters
+* Gains Tax (capital gains treatment) logic and parameters.
 
-### 0.8.0
+## [0.6.0] - 2021-12-28
 
-* Added minimum benefit logic for SNAP
+### Added
 
-### 0.9.0
+* Alternative Minimum Tax (AMT) income and liability logic.
+* Development tools for auto-generating unit tests for Tax-Calculator functions.
 
-* Added Social Security taxation logic
+## [0.5.0] - 
 
-### 0.10.0
+### Added
 
-* Added income-to-SMI variable, parameters and tests
+* Medicaid income thresholds for California.
 
+## [0.4.0] - 2021-12-26
+
+### Added
+
+* TANF eligibility, broken down into demographic and financial variables, with financial separated by current enrollment in program.
+* Demographic TANF eligibility per IL rules.
+
+## [0.3.1] - 2021-12-25
+
+### Added
+
+* Automated tests.
+
+## [0.3.0] - 2021-12-25
+
+### Added
+
+* Lifeline benefit.
+
+## 0.0.1 - 2021-06-28
+
+### Added
+
+* First prototype version with a standard deduction variable.


### PR DESCRIPTION
Fixes #413

No code changes - only reversing the changelog and adopting subheadings and formatting from http://keepachangelog.com.

Also exempts the changelog from file changes that require a version bump. Other changes in that file were automatic from my code formatter.