### PR TITLE
Add education tax credits

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md CHANGELOG.md Makefile .gitignore LICENSE* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore LICENSE* .github/*"
 
 last_tagged_commit=$(git describe --tags --abbrev=0 --first-parent) # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2021-12-30
+
+### Added
+
+* American Opportunity Credit
+* Lifetime Learning Credit
+
 ## [0.10.0] - 2021-12-28
 
 ### Added

--- a/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/amount.yaml
+++ b/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/amount.yaml
@@ -1,17 +1,17 @@
 description: Value of the maximum American Opportunity Credit, as a marginal rate schedule on tuition expenses
 brackets:
   - threshold:
-      2010-01-01: 0
+      2009-01-01: 0
     rate:
-      2010-01-01: 1
+      2009-01-01: 1
   - threshold:
-      2010-01-01: 2_000
+      2009-01-01: 2_000
     rate:
-      2010-01-01: 0.25
+      2009-01-01: 0.25
   - threshold:
-      2010-01-01: 4_000
+      2009-01-01: 4_000
     rate:
-      2010-01-01: 0
+      2009-01-01: 0
 metadata:
   type: marginal_rate
   rate_unit: /1

--- a/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/amount.yaml
+++ b/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/amount.yaml
@@ -1,0 +1,21 @@
+description: Value of the maximum American Opportunity Credit, as a marginal rate schedule on tuition expenses
+brackets:
+  - threshold:
+      2010-01-01: 0
+    rate:
+      2010-01-01: 1
+  - threshold:
+      2010-01-01: 2_000
+    rate:
+      2010-01-01: 0.25
+  - threshold:
+      2010-01-01: 4_000
+    rate:
+      2010-01-01: 0
+metadata:
+  type: marginal_rate
+  rate_unit: /1
+  threshold_unit: currency-USD
+  reference:
+    - title: 26 U.S. Code § 25A(b)(1)
+      url: https://www.law.cornell.edu/uscode/text/26/25A#b_1

--- a/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/refundability.yaml
+++ b/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/refundability.yaml
@@ -1,6 +1,6 @@
 description: Percentage of the American Opportunity Credit which is refundable
 values:
-  2010-01-01: 0.4
+  2009-01-01: 0.4
 metadata:
   unit: /1
   reference:

--- a/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/refundability.yaml
+++ b/openfisca_us/parameters/irs/credits/education/american_opportunity_credit/refundability.yaml
@@ -1,0 +1,8 @@
+description: Percentage of the American Opportunity Credit which is refundable
+values:
+  2010-01-01: 0.4
+metadata:
+  unit: /1
+  reference:
+    - title: 26 U.S. Code § 25A
+      url: https://www.law.cornell.edu/uscode/text/26/25A#i

--- a/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/expense_limit.yaml
+++ b/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/expense_limit.yaml
@@ -1,5 +1,8 @@
 description: Maximum expenses for relief under the Lifetime Learning Credit
 values:
-  2010-01-01: 10_000
+  1998-01-01: 10_000
 metadata:
   unit: currency-USD
+  reference:
+    - title: 26 U.S. Code § 25A(c)(1)
+      url: https://www.law.cornell.edu/uscode/text/26/25A#c_1

--- a/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/expense_limit.yaml
+++ b/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/expense_limit.yaml
@@ -1,0 +1,5 @@
+description: Maximum expenses for relief under the Lifetime Learning Credit
+values:
+  2010-01-01: 10_000
+metadata:
+  unit: currency-USD

--- a/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/rate.yaml
+++ b/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/rate.yaml
@@ -1,6 +1,6 @@
 description: Percentage of capped tuition expenses which is credited
 values:
-  2010-01-01: 0.2
+  1998-01-01: 0.2
 metadata:
   unit: /1
   reference:

--- a/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/rate.yaml
+++ b/openfisca_us/parameters/irs/credits/education/lifetime_learning_credit/rate.yaml
@@ -1,0 +1,8 @@
+description: Percentage of capped tuition expenses which is credited
+values:
+  2010-01-01: 0.2
+metadata:
+  unit: /1
+  reference:
+    - title: 26 U.S. Code § 25A(c)(1)
+      url: https://www.law.cornell.edu/uscode/text/26/25A#c_1

--- a/openfisca_us/parameters/irs/credits/education/phaseout.yaml
+++ b/openfisca_us/parameters/irs/credits/education/phaseout.yaml
@@ -12,10 +12,16 @@ start:
       unit: currency-USD
 length:
   description: Length of the phaseout for both the American Opportunity Credit and Lifetime Learning Credit on AGI (when excess income totals this amount, the credit is reduced to zero)
-  values:
-    2010-01-01: 10_000
-  metadata:
-    unit: currency-USD
+  single:
+    values:
+      2010-01-01: 10_000
+    metadata:
+      unit: currency-USD
+  joint:
+    values:
+      2010-01-01: 20_000
+    metadata:
+      unit: currency-USD
 metadata:
   reference:
     - title: 26 U.S. Code § 25A(d)(1)

--- a/openfisca_us/parameters/irs/credits/education/phaseout.yaml
+++ b/openfisca_us/parameters/irs/credits/education/phaseout.yaml
@@ -1,0 +1,22 @@
+start:
+  description: Phaseout start for both the American Opportunity Credit and Lifetime Learning Credit on AGI
+  single:
+    values:
+      2010-01-01: 80_000
+    metadata:
+      unit: currency-USD
+  joint:
+    values:
+      2010-01-01: 160_000
+    metadata:
+      unit: currency-USD
+length:
+  description: Length of the phaseout for both the American Opportunity Credit and Lifetime Learning Credit on AGI (when excess income totals this amount, the credit is reduced to zero)
+  values:
+    2010-01-01: 10_000
+  metadata:
+    unit: currency-USD
+metadata:
+  reference:
+    - title: 26 U.S. Code § 25A(d)(1)
+      url: https://www.law.cornell.edu/uscode/text/26/25A#d_1

--- a/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/american_opportunity_credit.yaml
+++ b/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/american_opportunity_credit.yaml
@@ -1,0 +1,24 @@
+- name: Not eligible, no credit
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    is_eligible_for_american_opportunity_credit: false
+    qualified_tuition_expenses: 1_000
+  output:
+    american_opportunity_credit: 0
+- name: Eligible, under first threshold of expenses
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    is_eligible_for_american_opportunity_credit: true
+    qualified_tuition_expenses: 1_000
+  output:
+    american_opportunity_credit: 1_000
+- name: Over phaseout, no entitlement
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    qualified_tuition_expenses: 1_000
+    adjusted_gross_income: 90_000
+  output:
+    american_opportunity_credit: 0

--- a/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/education_credit_phaseout.yaml
+++ b/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/education_credit_phaseout.yaml
@@ -1,0 +1,29 @@
+- name: No AGI, no phaseout
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    adjusted_gross_income: 0
+  output:
+    education_credit_phaseout: 0
+- name: AGI just over threshold, small phaseout
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    adjusted_gross_income: 81_000
+  output:
+    education_credit_phaseout: 0.1
+- name: AGI fully over end of phaseout
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    adjusted_gross_income: 90_000
+  output:
+    education_credit_phaseout: 1
+- name: Joint filer mid-way through phaseout
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    adjusted_gross_income: 170_000
+    tax_unit_is_joint: true
+  output:
+    education_credit_phaseout: 0.5

--- a/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/non_refundable_american_opportunity_credit.yaml
+++ b/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/non_refundable_american_opportunity_credit.yaml
@@ -1,0 +1,14 @@
+- name: No credit, no non-refundability
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    american_opportunity_credit: 0
+  output:
+    non_refundable_american_opportunity_credit: 0
+- name: Non-refundable is 60% of AOC
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    american_opportunity_credit: 1_000
+  output:
+    non_refundable_american_opportunity_credit: 600

--- a/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/refundable_american_opportunity_credit.yaml
+++ b/openfisca_us/tests/policy/baseline/irs/credits/education/american_opportuinity_credit/refundable_american_opportunity_credit.yaml
@@ -1,0 +1,14 @@
+- name: No credit, no refundability
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    american_opportunity_credit: 0
+  output:
+    refundable_american_opportunity_credit: 0
+- name: Refundable is 40% of AOC
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    american_opportunity_credit: 1_000
+  output:
+    refundable_american_opportunity_credit: 400

--- a/openfisca_us/tests/policy/baseline/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit.yaml
+++ b/openfisca_us/tests/policy/baseline/irs/credits/education/lifetime_learning_credit/lifetime_learning_credit.yaml
@@ -1,0 +1,30 @@
+- name: No expenses, no credit
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    qualified_tuition_expenses: 0
+  output:
+    lifetime_learning_credit: 0
+- name: Some entitlement
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    qualified_tuition_expenses: 1_000
+  output:
+    lifetime_learning_credit: 200
+- name: Eligibility for AOC disqualifies LLC
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    qualified_tuition_expenses: 1_000
+    is_eligible_for_american_opportunity_credit: true
+  output:
+    lifetime_learning_credit: 0
+- name: Over phaseout, no entitlement
+  period: 2020
+  absolute_error_margin: 0
+  input:
+    qualified_tuition_expenses: 1_000
+    adjusted_gross_income: 90_000
+  output:
+    lifetime_learning_credit: 0

--- a/openfisca_us/tools/general.py
+++ b/openfisca_us/tools/general.py
@@ -35,3 +35,13 @@ def sum_contained_tax_units(var, population, period):
 infinity = np.inf
 select = np.select
 where = np.where
+
+
+def variable_alias(name: str, variable_cls: type) -> type:
+    """
+    Copy a variable class and return a new class.
+    """
+    new_variable_cls = type(
+        name, variable_cls.__bases__, dict(variable_cls.__dict__)
+    )
+    return new_variable_cls

--- a/openfisca_us/tools/general.py
+++ b/openfisca_us/tools/general.py
@@ -41,6 +41,4 @@ def variable_alias(name: str, variable_cls: type) -> type:
     """
     Copy a variable class and return a new class.
     """
-    return type(
-        name, variable_cls.__bases__, dict(variable_cls.__dict__)
-    )
+    return type(name, variable_cls.__bases__, dict(variable_cls.__dict__))

--- a/openfisca_us/tools/general.py
+++ b/openfisca_us/tools/general.py
@@ -41,7 +41,6 @@ def variable_alias(name: str, variable_cls: type) -> type:
     """
     Copy a variable class and return a new class.
     """
-    new_variable_cls = type(
+    return type(
         name, variable_cls.__bases__, dict(variable_cls.__dict__)
     )
-    return new_variable_cls

--- a/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
+++ b/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
@@ -1,0 +1,82 @@
+from openfisca_us.model_api import *
+
+
+class american_opportunity_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "American Opportunity Credit"
+    unit = "currency-USD"
+    documentation = "Total value of the American Opportunity Credit"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#b"
+
+    def formula(tax_unit, period, parameters):
+        education = parameters(period).irs.credits.education
+        aoc = education.american_opportunity_credit
+        is_eligible = tax_unit.members(
+            "is_eligible_for_american_opportunity_credit", period
+        )
+        tuition_expenses = (
+            tax_unit.members("qualified_tuition_expenses", period)
+            * is_eligible
+        )
+        maximum_amount_per_student = aoc.amount.calc(tuition_expenses)
+        maximum_amount = tax_unit.sum(maximum_amount_per_student)
+        agi = tax_unit("adjusted_gross_income", period)
+        is_joint = tax_unit("tax_unit_is_joint", period)
+        phaseout_start = where(
+            is_joint,
+            education.phaseout.start.single,
+            education.phaseout.start.joint,
+        )
+        excess_agi = max(0, agi - phaseout_start)
+        percentage_reduction = excess_agi / maximum_amount
+        return max_(0, maximum_amount * (1 - percentage_reduction))
+
+
+class refundable_american_opportunity_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Refundable American Opportunity Credit"
+    unit = "currency-USD"
+    documentation = (
+        "Value of the refundable portion of the American Opportunity Credit"
+    )
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+
+    def formula(tax_unit, period, parameters):
+        aoc = parameters(
+            period
+        ).irs.credits.education.american_opportunity_credit
+        return aoc.refundability * tax_unit(
+            "american_opportunity_credit", period
+        )
+
+
+class non_refundable_american_opportunity_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Non-refundable American Opportunity Credit"
+    unit = "currency-USD"
+    documentation = "Value of the non-refundable portion of the American Opportunity Credit"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#i"
+
+    def formula(tax_unit, period):
+        total = tax_unit("american_opportunity_credit", period)
+        refundable = tax_unit("refundable_american_opportunity_credit", period)
+        return total - refundable
+
+
+class is_eligible_for_american_opportunity_credit(Variable):
+    value_type = bool
+    entity = Person
+    label = "Eligible for American Opportunity Credit"
+    documentation = "Whether the person is eligible for the AOC in respect of qualified tuition expenses for this tax year. The expenses must be for one of the first four years of post-secondary education, and the person must not have claimed the AOC for any four previous tax years."
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#b_2"
+
+    def formula(person, period):
+        # If the person's filing unit has a claim from Form 8863, use that to determine eligibility.
+        return person.tax_unit("e87521", period) > 0

--- a/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
+++ b/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
@@ -74,7 +74,7 @@ class is_eligible_for_american_opportunity_credit(Variable):
         return person.tax_unit("e87521", period) > 0
 
 
-class education_credit_phaseout_percentage(Variable):
+class education_credit_phaseout(Variable):
     value_type = float
     entity = TaxUnit
     label = "Education credit phase-out"

--- a/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
+++ b/openfisca_us/variables/irs/credits/education/american_opportunity_credit.py
@@ -88,13 +88,13 @@ class education_credit_phaseout(Variable):
         is_joint = tax_unit("tax_unit_is_joint", period)
         phaseout_start = where(
             is_joint,
-            education.phaseout.start.single,
             education.phaseout.start.joint,
+            education.phaseout.start.single,
         )
         phaseout_length = where(
             is_joint,
-            education.phaseout.length.single,
             education.phaseout.length.joint,
+            education.phaseout.length.single,
         )
         excess_agi = max(0, agi - phaseout_start)
         return min_(1, excess_agi / phaseout_length)

--- a/openfisca_us/variables/irs/credits/education/lifetime_learning_credit.py
+++ b/openfisca_us/variables/irs/credits/education/lifetime_learning_credit.py
@@ -13,22 +13,14 @@ class lifetime_learning_credit(Variable):
     def formula(tax_unit, period, parameters):
         education = parameters(period).irs.credits.education
         llc = education.lifetime_learning_credit
-        is_aoc_eligible = tax_unit.members(
+        person = tax_unit.members
+        is_aoc_eligible = person(
             "is_eligible_for_american_opportunity_credit", period
         )
         eligible_expenses = tax_unit.sum(
-            tax_unit.members("qualified_tuition_expenses", period)
-            * ~is_aoc_eligible
+            person("qualified_tuition_expenses", period) * ~is_aoc_eligible
         )
         capped_expenses = min_(llc.expense_limit, eligible_expenses)
         maximum_amount = llc.rate * capped_expenses
-        agi = tax_unit("adjusted_gross_income", period)
-        is_joint = tax_unit("tax_unit_is_joint", period)
-        phaseout_start = where(
-            is_joint,
-            education.phaseout.start.single,
-            education.phaseout.start.joint,
-        )
-        excess_agi = max(0, agi - phaseout_start)
-        percentage_reduction = excess_agi / maximum_amount
-        return max_(0, maximum_amount * (1 - percentage_reduction))
+        phaseout = tax_unit("education_credit_phaseout", period)
+        return max_(0, maximum_amount * (1 - phaseout))

--- a/openfisca_us/variables/irs/credits/education/lifetime_learning_credit.py
+++ b/openfisca_us/variables/irs/credits/education/lifetime_learning_credit.py
@@ -1,0 +1,34 @@
+from openfisca_us.model_api import *
+
+
+class lifetime_learning_credit(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = "Lifetime Learning Credit"
+    unit = "currency-USD"
+    documentation = "Value of the non-refundable Lifetime Learning Credit"
+    definition_period = YEAR
+    reference = "https://www.law.cornell.edu/uscode/text/26/25A#c"
+
+    def formula(tax_unit, period, parameters):
+        education = parameters(period).irs.credits.education
+        llc = education.lifetime_learning_credit
+        is_aoc_eligible = tax_unit.members(
+            "is_eligible_for_american_opportunity_credit", period
+        )
+        eligible_expenses = tax_unit.sum(
+            tax_unit.members("qualified_tuition_expenses", period)
+            * ~is_aoc_eligible
+        )
+        capped_expenses = min_(llc.expense_limit, eligible_expenses)
+        maximum_amount = llc.rate * capped_expenses
+        agi = tax_unit("adjusted_gross_income", period)
+        is_joint = tax_unit("tax_unit_is_joint", period)
+        phaseout_start = where(
+            is_joint,
+            education.phaseout.start.single,
+            education.phaseout.start.joint,
+        )
+        excess_agi = max(0, agi - phaseout_start)
+        percentage_reduction = excess_agi / maximum_amount
+        return max_(0, maximum_amount * (1 - percentage_reduction))

--- a/openfisca_us/variables/irs/inputs.py
+++ b/openfisca_us/variables/irs/inputs.py
@@ -965,9 +965,15 @@ class e87530(Variable):
     value_type = float
     entity = Person
     definition_period = YEAR
+    label = "Qualified tuition expenses"
     documentation = (
-        """Adjusted qualified lifetime learning expenses for all students"""
+        "Adjusted qualified lifetime learning expenses for all students"
     )
+
+
+qualified_tuition_expenses = variable_alias(
+    "qualified_tuition_expenses", e87530
+)
 
 
 class elderly_dependents(Variable):

--- a/openfisca_us/variables/irs/outputs.py
+++ b/openfisca_us/variables/irs/outputs.py
@@ -898,6 +898,14 @@ class c07230(Variable):
     definition_period = YEAR
     documentation = """Education tax credits non-refundable amount from Form 8863 (includes c87668)"""
 
+    def formula(tax_unit, period, parameters):
+        return add(
+            tax_unit,
+            period,
+            "non_refundable_american_opportunity_credit",
+            "lifetime_learning_credit",
+        )
+
 
 class c07240(Variable):
     value_type = float
@@ -1087,6 +1095,9 @@ class c10960(Variable):
     documentation = (
         """American Opportunity Credit refundable amount from Form 8863"""
     )
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit("refundable_american_opportunity_credit", period)
 
 
 class c11070(Variable):
@@ -1391,6 +1402,9 @@ class c87668(Variable):
     entity = TaxUnit
     definition_period = YEAR
     documentation = """American Opportunity Credit non-refundable amount from Form 8863 (included in c07230)"""
+
+    def formula(tax_unit, period, parameters):
+        return tax_unit("non_refundable_american_opportunity_credit", period)
 
 
 class care_deduction(Variable):

--- a/openfisca_us/variables/irs/outputs.py
+++ b/openfisca_us/variables/irs/outputs.py
@@ -500,6 +500,9 @@ class c00100(Variable):
         return add(tax_unit, period, "ymod1", "c02500", "c02900")
 
 
+adjusted_gross_income = variable_alias("adjusted_gross_income", c00100)
+
+
 class c01000(Variable):
     value_type = float
     entity = TaxUnit
@@ -1267,6 +1270,10 @@ class tax_unit_is_joint(Variable):
     label = "Joint-filing tax unit"
     documentation = "Whether this tax unit is a joint filer."
     definition_period = YEAR
+
+    def formula(tax_unit, period, parameters):
+        mars = tax_unit("mars", period)
+        return mars == mars.possible_values.JOINT
 
 
 class c59660(Variable):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.10.0",
+    version="0.11.0",
     author="Nikhil Woodruff",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
This implements the American Opportunity Credit and the Lifetime Learning Credit (from the [law](https://www.law.cornell.edu/uscode/text/26/25A#i), rather than taxcalc). This should fix both #103 and #105.

[tax-calc](https://github1s.com/pslmodels/tax-calculator/blob/HEAD/taxcalc/calcfunctions.py#L2599-L2600)

- [x] Add parameters
- [x] Add logic
- [x] Add tests