### PR TITLE
String tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2022-01-12
+
+### Fixed
+
+* Test runner failed to test string values.
+
 ## [0.20.0] - 2022-01-09
 
 ### Added

--- a/openfisca_us/tools/testing.py
+++ b/openfisca_us/tools/testing.py
@@ -10,7 +10,10 @@ import argparse
 
 import pytest
 
-from openfisca_core.tools import assert_near
+import numexpr
+
+from openfisca_core.indexed_enums import EnumArray
+from openfisca_core.tools import assert_enum_equals, assert_datetime_equals, eval_expression
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.errors import SituationParsingError, VariableNotFound
 from openfisca_core.scripts import build_tax_benefit_system
@@ -379,3 +382,46 @@ def _get_tax_benefit_system(baseline, reforms, extensions):
     _tax_benefit_system_cache[key] = current_tax_benefit_system
 
     return current_tax_benefit_system
+
+
+def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
+    '''
+
+      :param value: Value returned by the test
+      :param target_value: Value that the test should return to pass
+      :param absolute_error_margin: Absolute error margin authorized
+      :param message: Error message to be displayed if the test fails
+      :param relative_error_margin: Relative error margin authorized
+
+      Limit : This function cannot be used to assert near periods.
+
+    '''
+
+    import numpy as np
+
+    if absolute_error_margin is None and relative_error_margin is None:
+        absolute_error_margin = 0
+    if not isinstance(value, np.ndarray):
+        value = np.array(value)
+    if isinstance(value, EnumArray):
+        return assert_enum_equals(value, target_value, message)
+    if np.issubdtype(value.dtype, np.datetime64):
+        target_value = np.array(target_value, dtype = value.dtype)
+        assert_datetime_equals(value, target_value, message)
+    if isinstance(target_value, str):
+        target_value = eval_expression(target_value)
+        if isinstance(target_value, str):
+            assert value == np.array(target_value), '{}{} differs from {}'.format(message, value, target_value)
+
+    target_value = np.array(target_value).astype(np.float32)
+
+    value = np.array(value).astype(np.float32)
+    diff = abs(target_value - value)
+    if absolute_error_margin is not None:
+        assert (diff <= absolute_error_margin).all(), \
+            '{}{} differs from {} with an absolute margin {} > {}'.format(message, value, target_value,
+                diff, absolute_error_margin)
+    if relative_error_margin is not None:
+        assert (diff <= abs(relative_error_margin * target_value)).all(), \
+            '{}{} differs from {} with a relative margin {} > {}'.format(message, value, target_value,
+                diff, abs(relative_error_margin * target_value))

--- a/openfisca_us/tools/testing.py
+++ b/openfisca_us/tools/testing.py
@@ -13,7 +13,11 @@ import pytest
 import numexpr
 
 from openfisca_core.indexed_enums import EnumArray
-from openfisca_core.tools import assert_enum_equals, assert_datetime_equals, eval_expression
+from openfisca_core.tools import (
+    assert_enum_equals,
+    assert_datetime_equals,
+    eval_expression,
+)
 from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_core.errors import SituationParsingError, VariableNotFound
 from openfisca_core.scripts import build_tax_benefit_system
@@ -384,18 +388,24 @@ def _get_tax_benefit_system(baseline, reforms, extensions):
     return current_tax_benefit_system
 
 
-def assert_near(value, target_value, absolute_error_margin = None, message = '', relative_error_margin = None):
-    '''
+def assert_near(
+    value,
+    target_value,
+    absolute_error_margin=None,
+    message="",
+    relative_error_margin=None,
+):
+    """
 
-      :param value: Value returned by the test
-      :param target_value: Value that the test should return to pass
-      :param absolute_error_margin: Absolute error margin authorized
-      :param message: Error message to be displayed if the test fails
-      :param relative_error_margin: Relative error margin authorized
+    :param value: Value returned by the test
+    :param target_value: Value that the test should return to pass
+    :param absolute_error_margin: Absolute error margin authorized
+    :param message: Error message to be displayed if the test fails
+    :param relative_error_margin: Relative error margin authorized
 
-      Limit : This function cannot be used to assert near periods.
+    Limit : This function cannot be used to assert near periods.
 
-    '''
+    """
 
     import numpy as np
 
@@ -406,7 +416,7 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
     if isinstance(value, EnumArray):
         return assert_enum_equals(value, target_value, message)
     if np.issubdtype(value.dtype, np.datetime64):
-        target_value = np.array(target_value, dtype = value.dtype)
+        target_value = np.array(target_value, dtype=value.dtype)
         assert_datetime_equals(value, target_value, message)
     if isinstance(target_value, str):
         target_value = eval_expression(target_value)
@@ -416,15 +426,25 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
         value = np.array(value).astype(np.float32)
     except ValueError:
         # Data type not translatable to floating point, assert complete equality
-        assert np.array(value) == np.array(target_value), '{}{} differs from {}'.format(message, value, target_value)
+        assert np.array(value) == np.array(
+            target_value
+        ), "{}{} differs from {}".format(message, value, target_value)
         return
 
     diff = abs(target_value - value)
     if absolute_error_margin is not None:
-        assert (diff <= absolute_error_margin).all(), \
-            '{}{} differs from {} with an absolute margin {} > {}'.format(message, value, target_value,
-                diff, absolute_error_margin)
+        assert (
+            diff <= absolute_error_margin
+        ).all(), "{}{} differs from {} with an absolute margin {} > {}".format(
+            message, value, target_value, diff, absolute_error_margin
+        )
     if relative_error_margin is not None:
-        assert (diff <= abs(relative_error_margin * target_value)).all(), \
-            '{}{} differs from {} with a relative margin {} > {}'.format(message, value, target_value,
-                diff, abs(relative_error_margin * target_value))
+        assert (
+            diff <= abs(relative_error_margin * target_value)
+        ).all(), "{}{} differs from {} with a relative margin {} > {}".format(
+            message,
+            value,
+            target_value,
+            diff,
+            abs(relative_error_margin * target_value),
+        )

--- a/openfisca_us/tools/testing.py
+++ b/openfisca_us/tools/testing.py
@@ -410,12 +410,15 @@ def assert_near(value, target_value, absolute_error_margin = None, message = '',
         assert_datetime_equals(value, target_value, message)
     if isinstance(target_value, str):
         target_value = eval_expression(target_value)
-        if isinstance(target_value, str):
-            assert value == np.array(target_value), '{}{} differs from {}'.format(message, value, target_value)
 
-    target_value = np.array(target_value).astype(np.float32)
+    try:
+        target_value = np.array(target_value).astype(np.float32)
+        value = np.array(value).astype(np.float32)
+    except ValueError:
+        # Data type not translatable to floating point, assert complete equality
+        assert np.array(value) == np.array(target_value), '{}{} differs from {}'.format(message, value, target_value)
+        return
 
-    value = np.array(value).astype(np.float32)
     diff = abs(target_value - value)
     if absolute_error_margin is not None:
         assert (diff <= absolute_error_margin).all(), \

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.20.0",
+    version="0.20.1",
     author="Nikhil Woodruff",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
# Bug fix: string tests

## What this fixes and how it's fixed

The test runner now attempts to evaluate string, but if the result is still a string, it'll assert equality.
