### PR TITLE
Add metadata to SNAP variables and parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 * Add metadata for variables and parameters used in SNAP calculations.
+* Renames two parameters involved in SNAP deductions from `threshold` to `disregard`.
 
 ## [0.24.0] - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [0.24.1] - 2022-01-17
+
+## Changed
+
+* Add metadata for variables and parameters used in SNAP calculations.
+
 ## [0.24.0] - 2022-01-17
 
 ### Added

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/disregard.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/disregard.yaml
@@ -1,4 +1,4 @@
-description: Threshold for excess medical expenses to quality for the deduction.
+description: Monthly medical expenses disregarded for claiming SNAP excess medical expense deduction
 values:
   2018-01-01: 35
 metadata:
@@ -7,5 +7,5 @@ metadata:
       href: https://www.law.cornell.edu/uscode/text/7/2014#e_5
   unit: currency-USD
   period: month
-  label: SNAP medical expense threshold
-  name: snap_medical_expense_threshold
+  label: Medical expense disregard for SNAP excess medical expense deduction
+  name: snap_medical_expense_disregard

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/threshold.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/threshold.yaml
@@ -7,3 +7,5 @@ metadata:
       href: https://www.law.cornell.edu/uscode/text/7/2014#e_5
   unit: currency-USD
   period: month
+  label: SNAP medical expense threshold
+  name: snap_medical_expense_threshold

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/homeless.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/homeless.yaml
@@ -22,3 +22,5 @@ values:
 metadata:
   unit: currency-USD
   period: month
+  label: SNAP homeless shelter deduction
+  name: snap_homeless_shelter_deduction

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/income_share_disregard.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/income_share_disregard.yaml
@@ -1,4 +1,4 @@
-description: Income share threshold applied to SNAP shelter deduction
+description: Share of income disregarded for SNAP shelter deduction
 
 values:
   2018-01-01: 0.5

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/income_share_threshold.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/income_share_threshold.yaml
@@ -8,3 +8,5 @@ metadata:
   reference:
     - title: 7 U.S. Code § 2014(e)(6)(A)
       href: https://www.law.cornell.edu/uscode/text/7/2014#e_6_A
+  label: Share of income disregarded for SNAP shelter deduction
+  name: snap_shelter_deduction_income_share_disregard

--- a/openfisca_us/variables/expense/childcare/childcare_expenses.py
+++ b/openfisca_us/variables/expense/childcare/childcare_expenses.py
@@ -5,5 +5,6 @@ class childcare_expenses(Variable):
     value_type = float
     entity = SPMUnit
     label = "Child care expenses"
+    documentation = "Out of pocket spending on childcare"
     definition_period = YEAR
     unit = USD

--- a/openfisca_us/variables/expense/childcare/childcare_expenses.py
+++ b/openfisca_us/variables/expense/childcare/childcare_expenses.py
@@ -6,3 +6,4 @@ class childcare_expenses(Variable):
     entity = SPMUnit
     label = "Child care expenses"
     definition_period = YEAR
+    unit = USD

--- a/openfisca_us/variables/usda/snap/income/deductions/shelter/snap_excess_shelter_expense_deduction.py
+++ b/openfisca_us/variables/usda/snap/income/deductions/shelter/snap_excess_shelter_expense_deduction.py
@@ -21,7 +21,7 @@ class snap_excess_shelter_expense_deduction(Variable):
         net_income_pre_shelter = spm_unit(
             "snap_net_income_pre_shelter", period
         )
-        subtracted_income = p.income_share_threshold * net_income_pre_shelter
+        subtracted_income = p.income_share_disregard * net_income_pre_shelter
         housing_cost = spm_unit("housing_cost", period)
         uncapped_ded = max_(housing_cost - subtracted_income, 0)
         # Calculate capped deduction based on state group parameter.

--- a/openfisca_us/variables/usda/snap/income/deductions/snap_excess_medical_expense_deduction.py
+++ b/openfisca_us/variables/usda/snap/income/deductions/snap_excess_medical_expense_deduction.py
@@ -23,8 +23,8 @@ class snap_excess_medical_expense_deduction(Variable):
         p = parameters(
             period
         ).usda.snap.income.deductions.excess_medical_expense
-        threshold = p.threshold * 12
-        excess = max_(elderly_disabled_moop - threshold, 0)
+        disregard = p.disregard * 12
+        excess = max_(elderly_disabled_moop - disregard, 0)
         # Calculate standard medical deduction (SMD).
         state = spm_unit.household("state_code_str", period)
         standard = p.standard[state] * 12

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.24.0",
+    version="0.24.1",
     author="Nikhil Woodruff",
     author_email="nikhil@policyengine.org",
     classifiers=[


### PR DESCRIPTION
Also renames two parameters from `threshold` to `disregard` which I think better captures their purpose.

Fixes #496