### PR TITLE
Add guaranteed income / cash assistance variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [0.30.0] - 2022-02-07
+
+### Added
+
+* Guaranteed income / cash assistance pilot income variable. This counts as unearned income for SNAP, uncounted for taxes and other benefits.
+
 ## [0.29.0] - 2022-02-07
 
 ### Added
@@ -301,6 +307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * First prototype version with a standard deduction variable.
 
+[0.30.0]: https://github.com/PolicyEngine/openfisca-us/compare/0.29.0...0.30.0
 [0.29.0]: https://github.com/PolicyEngine/openfisca-us/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/PolicyEngine/openfisca-us/compare/0.27.2...0.28.0
 [0.27.2]: https://github.com/PolicyEngine/openfisca-us/compare/0.27.1...0.27.2

--- a/openfisca_us/parameters/usda/school_meals/income/sources.yaml
+++ b/openfisca_us/parameters/usda/school_meals/income/sources.yaml
@@ -6,6 +6,7 @@ values:
     - self_employment_income
     - dividend_income
     - interest_income
+    - gi_cash_assistance
 
 metadata:
   reference:

--- a/openfisca_us/parameters/usda/snap/income/sources/unearned.yaml
+++ b/openfisca_us/parameters/usda/snap/income/sources/unearned.yaml
@@ -4,6 +4,7 @@ values:
   2009-01-01:
     - dividend_income
     - interest_income
+    - gi_cash_assistance
 
 metadata:
   reference:

--- a/openfisca_us/tests/policy/baseline/income/spm_unit/spm_unit_benefits.yaml
+++ b/openfisca_us/tests/policy/baseline/income/spm_unit/spm_unit_benefits.yaml
@@ -3,9 +3,10 @@
   input:
     # Person-level.
     ssdi: 1
+    gi_cash_assistance: 5
     # SPM unit-level.
     snap: 2
     school_meal_subsidy: 3
     ssi: 4
   output:
-    spm_unit_benefits: 1 + 2 + 3 + 4
+    spm_unit_benefits: 1 + 5 + 2 + 3 + 4

--- a/openfisca_us/tests/policy/baseline/usda/school_meals/school_meal_countable_income.yaml
+++ b/openfisca_us/tests/policy/baseline/usda/school_meals/school_meal_countable_income.yaml
@@ -18,8 +18,9 @@
         self_employment_income: 10_000
       p2:
         dividend_income: 20_000
+        gi_cash_assistance: 500
     spm_units:
       spm_unit:
         members: [p1, p2]
   output:
-    school_meal_countable_income: 30_000
+    school_meal_countable_income: 30_500

--- a/openfisca_us/tests/policy/baseline/usda/snap/integration.yaml
+++ b/openfisca_us/tests/policy/baseline/usda/snap/integration.yaml
@@ -42,7 +42,8 @@
 - name: Single person in CA at 200% of FPL + $1 is ineligible.
   period: 2022
   input:
-    employment_income: 12_880 * 2 + 1
+    employment_income: 12_880 * 2
+    gi_cash_assistance: 1
     state_code_str: CA
   output:
     snap: 0

--- a/openfisca_us/variables/income/person/gi_cash_assistance.py
+++ b/openfisca_us/variables/income/person/gi_cash_assistance.py
@@ -1,0 +1,10 @@
+from openfisca_us.model_api import *
+
+
+class gi_cash_assistance(Variable):
+    value_type = float
+    entity = Person
+    label = "Guaranteed income / cash assistance income"
+    unit = USD
+    documentation = "Income from guaranteed income or cash assistance pilots"
+    definition_period = YEAR

--- a/openfisca_us/variables/income/spm_unit/spm_unit_benefits.py
+++ b/openfisca_us/variables/income/spm_unit/spm_unit_benefits.py
@@ -11,6 +11,7 @@ class spm_unit_benefits(Variable):
     def formula(spm_unit, period, parameters):
         PERSON_COMPONENTS = [
             "ssdi",
+            "gi_cash_assistance",
         ]
         SPMU_COMPONENTS = [
             "snap",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="OpenFisca-US",
-    version="0.29.0",
+    version="0.30.0",
     author="Nikhil Woodruff",
     author_email="nikhil@policyengine.org",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="OpenFisca tax and benefit system for the US",


### PR DESCRIPTION
Fixes #537

# New variable: `gi_cash_assistance`

- [x] Label field added
- [x] Documentation field added
- [x] Unit field added
- [x] Variable name follows conventions

## What's changed

This variable counts as `spm_unit_benefits`, `snap_unearned_income`, and `school_meals_countable_income`, but no other income sources. It doesn't count toward taxable income, and Lifeline uses IRS gross income, so it wouldn't count for that either. Pilot administrators have told me that it counts for SNAP, and I've assumed that it also counts for school meal subsidies, given they're both USDA programs, but I filed #549 to verify that. I don't know if it counts for CVRP, and filed #550 for that.

I'm indifferent between this name, `guaranteed_income_cash_assistance`, `cash_assistance_guaranteed_income`, etc.