### PR TITLE
Add CPS URL

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -556,3 +556,7 @@
   changes:
     added:
       - Basic income now included in SPM unit benefits.
+- bump: patch
+  changes:
+    added:
+      - URL from which to download the latest CPS dataset (skipping generation)

--- a/openfisca_us/data/datasets/cps/cps.py
+++ b/openfisca_us/data/datasets/cps/cps.py
@@ -13,7 +13,9 @@ class CPS(PublicDataset):
     model = "openfisca_us"
     folder_path = OPENFISCA_US_MICRODATA_FOLDER
 
-    url_by_year = {2020: "https://some_url.org"}
+    url_by_year = {
+        2020: "https://github.com/PolicyEngine/openfisca-us/releases/download/cps-v0/cps_2020.h5"
+    }
 
     def generate(self, year: int):
         """Generates the Current Population Survey dataset for OpenFisca-US microsimulations.


### PR DESCRIPTION
So that you can run: `openfisca-us-data cps download 2020` rather than having to compile it from scratch.