### PR TITLE
Add early termination logic to Premium Tax Credit formula

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -738,3 +738,7 @@
     fixed:
     - A bug causing the CDCC to not cap at the two-child childcare max expenses.
   date: 2022-05-30 22:40:36
+- bump: patch
+  changes:
+    changed:
+    - Premium Tax Credit formula skips intensive calculations if all tax units are ineligible.

--- a/openfisca_us/variables/gov/irs/credits/premium_tax_credit/premium_tax_credit.py
+++ b/openfisca_us/variables/gov/irs/credits/premium_tax_credit/premium_tax_credit.py
@@ -10,8 +10,12 @@ class premium_tax_credit(Variable):
     reference = "https://www.law.cornell.edu/uscode/text/26/36B"
 
     def formula(tax_unit, period, parameters):
-        applicable_percentage = tax_unit("ptc_phase_out_rate", period)
         eligible = tax_unit("is_ptc_eligible", period)
+        if all(~eligible):
+            # If every tax unit is ineligible, skip the rest of the calculation
+            # and return zero values.
+            return eligible.astype(np.float32)
+        applicable_percentage = tax_unit("ptc_phase_out_rate", period)
         plan_cost = tax_unit("second_lowest_silver_plan_cost", period)
         income = tax_unit("medicaid_income", period)
         return eligible * max_(0, plan_cost - income * applicable_percentage)


### PR DESCRIPTION
Adds in @martinholmer's local change, which I think is a good idea to add in the meantime before we figure out a better solution to the intensive SLSPC matching process.