### PR TITLE
Specify breakdowns as lists

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -819,3 +819,7 @@
     added:
     - Metadata for MA policy.
   date: 2022-06-08 05:07:17
+- bump: patch
+  changes:
+    changed:
+    - Breakdowns always specified as a list.

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/adult/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/adult/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_adult_income_limit
   label: Medicaid adult income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/infant/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/infant/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_infant_income_limit
   label: Medicaid infant income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/older_child/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/older_child/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_older_child_income_limit
   label: Medicaid older child income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/parent/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_parent_income_limit
   label: Medicaid parent income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/pregnant/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/pregnant/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_pregnant_income_limit
   label: Medicaid pregnant income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=36

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/pregnant/postpartum_coverage.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/pregnant/postpartum_coverage.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: day
   name: medicaid_postpartum_coverage
   label: "Medicaid postpartum coverage"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: 42 U.S. Code § 1396a(e)(5)
       href: https://www.law.cornell.edu/uscode/text/42/1396a#e_5

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/couple.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/couple.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: currency-USD
   name: medicaid_senior_disabled_asset_limit_couple
   label: "Medicaid senior or disabled asset limit (couple)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/individual.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/assets/limit/individual.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: medicaid_senior_disabled_asset_limit_individual
   label: "Medicaid senior or disabled asset limit (individual)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/disregard/couple.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/disregard/couple.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: medicaid_senior_disabled_income_disregard_couple
   label: "Medicaid senior or disabled income disregard (couple)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/disregard/individual.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/disregard/individual.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: medicaid_senior_disabled_income_disregard_individual
   label: "Medicaid senior or disabled income disregard (individual)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/limit/couple.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/limit/couple.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: medicaid_senior_disabled_income_limit_couple
   label: "Medicaid senior or disabled income limit (couple)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/limit/individual.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/senior_or_disabled/income/limit/individual.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: medicaid_senior_disabled_income_limit_individual
   label: "Medicaid senior or disabled income limit (individual)"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: "Medicaid Financial Eligibility for Seniors and People with Disabilities: Findings from a 50-State Survey | KFF"
       href: https://www.kff.org/report-section/medicaid-financial-eligibility-for-seniors-and-people-with-disabilities-findings-from-a-50-state-survey-appendix-tables/

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/ssi_recipient/is_covered.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/ssi_recipient/is_covered.yaml
@@ -4,7 +4,8 @@ metadata:
   unit: bool
   name: medicaid_covers_all_ssi_recipients
   label: "Medicaid covers all SSI recipients"
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: 42 U.S. Code § 1396(f)
       href: https://www.law.cornell.edu/uscode/text/42/1396a#f

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/young_adult/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/young_adult/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_pregnant_income_limit
   label: Medicaid pregnant income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=36

--- a/openfisca_us/parameters/hhs/medicaid/eligibility/categories/young_child/income_limit.yaml
+++ b/openfisca_us/parameters/hhs/medicaid/eligibility/categories/young_child/income_limit.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: medicaid_young_child_income_limit
   label: Medicaid young child income limit
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: Medicaid and CHIP Eligibility and Enrollment Policies as of January 2022 | KFF
       href: https://files.kff.org/attachment/REPORT-Medicaid-and-CHIP-Eligibility-and-Enrollment-Policies-as-of-January-2022.pdf#page=33

--- a/openfisca_us/parameters/hhs/tanf/cash/amount/countable_income/deductions/earnings/percent.yaml
+++ b/openfisca_us/parameters/hhs/tanf/cash/amount/countable_income/deductions/earnings/percent.yaml
@@ -18,4 +18,5 @@ CA:
         href: https://ehsd.org/benefits/calworks-cash-aid/calworks-fact-sheet/
 metadata:
   unit: /1
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/cash/amount/countable_income/deductions/household.yaml
+++ b/openfisca_us/parameters/hhs/tanf/cash/amount/countable_income/deductions/household.yaml
@@ -12,4 +12,5 @@ CA:
 metadata:
   unit: currency-USD
   period: month
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/non_cash/asset_limit.yaml
+++ b/openfisca_us/parameters/hhs/tanf/non_cash/asset_limit.yaml
@@ -117,4 +117,5 @@ metadata:
     - title: "USDA: Broad-based Categorical Eligibility"
       href: https://fns-prod.azureedge.net/sites/default/files/resource-files/BBCE%20States%20Chart%20(July%202021).pdf
       date: 2021-07-01
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/gross.yaml
+++ b/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/gross.yaml
@@ -113,4 +113,5 @@ metadata:
     - title: "USDA: Broad-based Categorical Eligibility"
       href: https://fns-prod.azureedge.net/sites/default/files/resource-files/BBCE%20States%20Chart%20(July%202021).pdf
       date: 2021-07-01
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/net_applies/hheod.yaml
+++ b/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/net_applies/hheod.yaml
@@ -93,4 +93,5 @@ metadata:
   reference:
     - title: SNAP Screener SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/net_applies/non_hheod.yaml
+++ b/openfisca_us/parameters/hhs/tanf/non_cash/income_limit/net_applies/non_hheod.yaml
@@ -93,4 +93,5 @@ metadata:
   reference:
     - title: SNAP Screener SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/hhs/tanf/non_cash/requires_all_for_hheod.yaml
+++ b/openfisca_us/parameters/hhs/tanf/non_cash/requires_all_for_hheod.yaml
@@ -29,4 +29,5 @@ metadata:
   reference:
     - title: SNAP Screener SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/openfisca/completed_programs/state.yaml
+++ b/openfisca_us/parameters/openfisca/completed_programs/state.yaml
@@ -161,4 +161,5 @@ WY:
   2021-01-01:
     - SNAP
 metadata:
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/states/ca/per_vehicle_payment/amount.yaml
+++ b/openfisca_us/parameters/states/ca/per_vehicle_payment/amount.yaml
@@ -10,6 +10,7 @@ CA:
 metadata:
   unit: currency-USD
   period: year
-  breakdown: state_code
+  breakdown:
+  - state_code
   name: per_vehicle_payment_amount
   label: Per-vehicle payment amount

--- a/openfisca_us/parameters/states/ca/per_vehicle_payment/max_vehicles.yaml
+++ b/openfisca_us/parameters/states/ca/per_vehicle_payment/max_vehicles.yaml
@@ -9,6 +9,7 @@ CA:
           href: https://www.gov.ca.gov/2022/03/23/governor-newsom-proposes-11-billion-relief-package-for-californians-facing-higher-gas-prices/
 metadata:
   unit: vehicle
-  breakdown: state_code
+  breakdown:
+  - state_code
   name: per_vehicle_payment_max_vehicles
   label: Maximum number of vehicles

--- a/openfisca_us/parameters/states/ma/tax/income/deductions/rent/cap.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/deductions/rent/cap.yaml
@@ -39,6 +39,7 @@ metadata:
       href: https://www.mass.gov/doc/2011-form-1-instructions/download#page=20
   unit: currency-USD
   period: year
-  breakdown: filing_status
+  breakdown:
+  - filing_status
   name: ma_income_tax_rent_deduction_cap
   label: Maximum rental deduction for MA income taxes.

--- a/openfisca_us/parameters/states/ma/tax/income/exempt_status/limit/base.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exempt_status/limit/base.yaml
@@ -19,6 +19,7 @@ metadata:
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section5
   unit: currency-USD
   period: year
-  breakdown: filing_status
+  breakdown:
+  - filing_status
   name: ma_income_tax_no_tax_status_limit
   label: AGI addition to limit to be exempt from MA income tax.

--- a/openfisca_us/parameters/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exempt_status/limit/personal_exemption_added.yaml
@@ -15,6 +15,7 @@ metadata:
       href: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleIX/Chapter62/Section5
   unit: currency-USD
   period: year
-  breakdown: filing_status
+  breakdown:
+  - filing_status
   name: ma_income_tax_no_tax_status_limit_personal_exemption_added
   label: MA income tax exemption limit includes personal exemptions

--- a/openfisca_us/parameters/states/ma/tax/income/exemptions/aged/amount.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exemptions/aged/amount.yaml
@@ -9,6 +9,7 @@ metadata:
       href: https://www.mass.gov/doc/2021-form-1-massachusetts-resident-income-tax-return/download
   unit: currency-USD
   period: year
-  breakdown: state_code
+  breakdown:
+  - state_code
   name: ma_income_tax_aged_exemption
   label: MA income tax aged exemption

--- a/openfisca_us/parameters/states/ma/tax/income/exemptions/dependent.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exemptions/dependent.yaml
@@ -11,6 +11,7 @@ metadata:
       href: https://taxfoundation.org/publications/state-individual-income-tax-rates-and-brackets/
   unit: currency-USD
   period: year
-  breakdown: state_code
+  breakdown:
+  - state_code
   name: ma_income_tax_dependent_exemption
   label: MA income tax dependent exemption

--- a/openfisca_us/parameters/states/ma/tax/income/exemptions/interest.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exemptions/interest.yaml
@@ -12,7 +12,8 @@ SEPARATE:
 metadata:
   unit: currency-USD
   period: year
-  breakdown: filing_status
+  breakdown:
+  - filing_status
   name: ma_interest_exemption
   label: MA interest exemption
   reference:

--- a/openfisca_us/parameters/states/ma/tax/income/exemptions/personal.yaml
+++ b/openfisca_us/parameters/states/ma/tax/income/exemptions/personal.yaml
@@ -61,6 +61,7 @@ JOINT:
 metadata:
   unit: currency-USD
   period: year
-  breakdown: filing_status
+  breakdown:
+  - filing_status
   name: ma_income_tax_personal_exemption
   label: MA income tax personal exemption

--- a/openfisca_us/parameters/usda/snap/emergency_allotment/in_effect.yaml
+++ b/openfisca_us/parameters/usda/snap/emergency_allotment/in_effect.yaml
@@ -176,4 +176,5 @@ metadata:
       href: https://www.fns.usda.gov/disaster/pandemic/covid-19/california#snap
     - title: SNAP COVID-19 Emergency Allotments Guidance
       href: https://www.fns.usda.gov/snap/covid-19-emergency-allotments-guidance
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/usda/snap/income/deductions/child_support.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/child_support.yaml
@@ -160,7 +160,8 @@ WY:
   2021-10-01: true
 metadata:
   unit: bool
-  breakdown: state_code
+  breakdown:
+  - state_code
   reference:
     - title: SNAP Screener SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/standard.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_medical_expense/standard.yaml
@@ -164,4 +164,5 @@ metadata:
       href: https://www.snapscreener.com/?p=table
   unit: currency-USD
   period: month
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/homeless/available.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/excess_shelter_expense/homeless/available.yaml
@@ -162,4 +162,5 @@ metadata:
   unit: bool
   name: snap_homeless_shelter_deduction_available
   label: SNAP homeless shelter deduction available
-  breakdown: state_code
+  breakdown:
+  - state_code

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/limited/active.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/limited/active.yaml
@@ -162,4 +162,5 @@ metadata:
   unit: bool
   name: snap_lua_active
   label: SNAP Limited Utility Allowance active
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/limited/allowance.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/limited/allowance.yaml
@@ -166,5 +166,6 @@ metadata:
       href: https://www.fns.usda.gov/snap/eligibility/deduction/standard-utility-allowances
     - name: SNAP Screener | SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
   name: snap_lua

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/electricity.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/electricity.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_electricity
   label: SNAP standard utility allowance for electricity expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 85

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/gas_and_fuel.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/gas_and_fuel.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_gas
   label: SNAP standard utility allowance for gas and fuel expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 113

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/phone.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/phone.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_expenses
   label: SNAP standard utility allowance for phone expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 15

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/sewage.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/sewage.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_sewage
   label: SNAP standard utility allowance for sewage expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 37

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/trash.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/trash.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_trash
   label: SNAP standard utility allowance for trash expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 12

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/single/water.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/single/water.yaml
@@ -4,7 +4,8 @@ metadata:
   period: month
   name: snap_utility_water
   label: SNAP standard utility allowance for water expenses
-  breakdown: snap_utility_region
+  breakdown:
+  - snap_utility_region
 AK:
   2010-01-01: 0
   2021-10-01: 37

--- a/openfisca_us/parameters/usda/snap/income/deductions/utility/standard.yaml
+++ b/openfisca_us/parameters/usda/snap/income/deductions/utility/standard.yaml
@@ -166,6 +166,7 @@ metadata:
       href: https://www.fns.usda.gov/snap/eligibility/deduction/standard-utility-allowances
     - name: SNAP Screener | SNAP Eligibility Parameters
       href: https://www.snapscreener.com/?p=table
-  breakdown: state_code
+  breakdown:
+  - state_code
   name: snap_utility_region
   label: SNAP standard utility allowance

--- a/openfisca_us/parameters/usda/snap/max_allotment.yaml
+++ b/openfisca_us/parameters/usda/snap/max_allotment.yaml
@@ -243,7 +243,8 @@ main:
 
 additional:
   metadata:
-    breakdown: snap_region
+    breakdown:
+    - snap_region
   CONTIGUOUS_US:
     2020-10-01: 153
     2021-01-01: 176

--- a/openfisca_us/parameters/usda/wic/nutritional_risk.yaml
+++ b/openfisca_us/parameters/usda/wic/nutritional_risk.yaml
@@ -3,7 +3,8 @@ metadata:
   unit: /1
   name: wic_nutritional_risk
   label: WIC nutritional risk
-  breakdown: wic_category
+  breakdown:
+  - wic_category
   reference:
     - title: "Estimating Eligibility and Participation for the WIC Program: Phase I Report"
       href: https://www.ncbi.nlm.nih.gov/books/NBK223565/pdf/Bookshelf_NBK223565.pdf

--- a/openfisca_us/parameters/usda/wic/takeup.yaml
+++ b/openfisca_us/parameters/usda/wic/takeup.yaml
@@ -1,7 +1,8 @@
 description: Percentage of WIC-eligible individuals that participate.
 metadata:
   unit: /1
-  breakdown: wic_category
+  breakdown:
+  - wic_category
   name: wic_takeup
   label: WIC takeup rate
   reference:


### PR DESCRIPTION
I think this should fix the capitalised breakdowns currently on the MA section in PolicyEngine.