### PR TITLE
Fix AMT income

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1019,3 +1019,7 @@
     changed:
     - Tests now don't stop after the first failure.
   date: 2022-06-29 01:00:28
+- bump: patch
+  changed:
+    fixed:
+    - AMT income formula now uses a legislative source.

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1020,6 +1020,6 @@
     - Tests now don't stop after the first failure.
   date: 2022-06-29 01:00:28
 - bump: patch
-  changed:
+  changes:
     fixed:
     - AMT income formula now uses a legislative source.

--- a/openfisca_us/tests/policy/baseline/taxsim/misc/general.yaml
+++ b/openfisca_us/tests/policy/baseline/taxsim/misc/general.yaml
@@ -224,3 +224,42 @@
   output:
     taxsim_tfica: 0.00
     income_tax: 0.00
+
+- name: Tax unit with taxsimid 11991 from q21.its.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 39
+        employment_income: 160000
+        social_security: 19000
+        real_estate_taxes: 11000
+        interest_expense: 36000
+      person2:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 11
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    taxsim_tfica: 11173.60
+    #tax_unit_taxable_unemployment_compensation: 0.00
+    #tax_unit_taxable_social_security: 16150.00
+    #adjusted_gross_income: 176150.00
+    #taxable_income: 130150.00
+    #cdcc: 0.00
+    #non_refundable_ctc: 2000.00
+    #refundable_ctc: 2000.00
+    #eitc: 0.00
+    income_tax: 21805.00


### PR DESCRIPTION
This adds a legislative reference and edits the AMT income variable, meeting a new integration test provided by @martinholmer. Fixes #1005.