### PR TITLE
Fix 2021 CTC refundable amount

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1029,3 +1029,7 @@
     added:
     - MA Senior Circuit Breaker credit.
   date: 2022-07-02 06:09:09
+- bump: patch
+  changes:
+    fixed:
+    - Fixed the CTC formula in 2021 (only) to correctly apply the income-based reduction.

--- a/openfisca_us/variables/gov/irs/credits/ctc/refundable_ctc.py
+++ b/openfisca_us/variables/gov/irs/credits/ctc/refundable_ctc.py
@@ -81,7 +81,9 @@ class refundable_ctc(Variable):
         return min_(maximum_refundable_ctc, amount_ctc_would_increase)
 
     def formula_2021(tax_unit, period, parameters):
-        maximum_amount = add(tax_unit, period, ["ctc_refundable_individual_maximum"])
+        maximum_amount = add(
+            tax_unit, period, ["ctc_refundable_individual_maximum"]
+        )
         reduction = tax_unit("ctc_reduction", period)
         return max_(0, maximum_amount - reduction)
 

--- a/openfisca_us/variables/gov/irs/credits/ctc/refundable_ctc.py
+++ b/openfisca_us/variables/gov/irs/credits/ctc/refundable_ctc.py
@@ -22,7 +22,7 @@ class refundable_ctc(Variable):
 
         total_ctc = tax_unit("ctc", period)
         maximum_refundable_ctc = min_(
-            aggr(tax_unit, period, ["ctc_refundable_individual_maximum"]),
+            add(tax_unit, period, ["ctc_refundable_individual_maximum"]),
             total_ctc,
         )
 
@@ -32,7 +32,7 @@ class refundable_ctc(Variable):
         # - Social Security tax minus the EITC
         # First, we find tax_increase:
 
-        earnings = aggr(tax_unit, period, ["earned_income"])
+        earnings = add(tax_unit, period, ["earned_income"])
         earnings_over_threshold = max_(
             0, earnings - ctc.refundable.phase_in.threshold
         )
@@ -80,7 +80,10 @@ class refundable_ctc(Variable):
 
         return min_(maximum_refundable_ctc, amount_ctc_would_increase)
 
-    formula_2021 = sum_of_variables(["ctc_refundable_individual_maximum"])
+    def formula_2021(tax_unit, period, parameters):
+        maximum_amount = add(tax_unit, period, ["ctc_refundable_individual_maximum"])
+        reduction = tax_unit("ctc_reduction", period)
+        return max_(0, maximum_amount - reduction)
 
     formula_2022 = formula
 


### PR DESCRIPTION
Fixes a bug causing the refundable CTC in 2021 (only) to miss out the income-based reduction.