### PR TITLE
Include non-tax-exempt Social Security benefits in income for Massachusetts Senior Circuit Breaker Credit income definition

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1034,3 +1034,7 @@
     fixed:
     - Fixed the CTC formula in 2021 (only) to correctly apply the income-based reduction.
   date: 2022-07-03 21:47:43
+- bump: patch
+  changes:
+    fixed:
+    - Include non-tax-exempt Social Security benefits in income for Massachusetts Senior Circuit Breaker Credit income definition.

--- a/openfisca_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
+++ b/openfisca_us/parameters/gov/states/ma/tax/income/credits/senior_circuit_breaker/income/disallowed_deductions.yaml
@@ -1,7 +1,7 @@
 description: Income sources re-added to total income for the MA Senior Circuit Breaker credit.
 values:
   2001-01-01:
-    - tax_exempt_social_security
+    - social_security
     - tax_exempt_unemployment_compensation
     - tax_exempt_pension_income
     - tax_exempt_interest_income


### PR DESCRIPTION
Fixes #1031