### PR TITLE
Use child cap or scale consistently for MA dependent credits

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1152,3 +1152,7 @@
     added:
     - MD CTC
   date: 2022-07-16 03:04:11
+- bump: patch
+  changes:
+    changed:
+    - Change MA dependent care credit from a scale parameter to an amount/cap structure.

--- a/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent/dependent_cap.yaml
+++ b/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent/dependent_cap.yaml
@@ -7,5 +7,5 @@ metadata:
       href: https://www.mass.gov/doc/2021-form-1-instructions/download#page=17
   unit: people
   period: year
-  name: ma_dependent_credit_cap
-  label: MA dependent credit cap
+  name: ma_dependent_credit_dependent_cap
+  label: MA dependent credit dependent cap

--- a/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent_care/amount.yaml
+++ b/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent_care/amount.yaml
@@ -1,20 +1,11 @@
-description: MA dependent care credit amount by number of qualifying individuals.
+description: MA dependent care credit amount per dependent
 metadata:
   reference:
     - title: Mass. General Laws c.62 § 6(x)
       href: https://www.mass.gov/info-details/mass-general-laws-c62-ss-6#(x)-
-  type: single_amount
-  threshold_unit: person
-  amount_unit: currency-USD
+  unit: currency-USD
   period: year
   name: ma_dependent_care_credit_amount
   label: MA dependent care credit
-brackets:
-  - threshold:
-      2021-01-01: 1
-    amount:
-      2021-01-01: 240
-  - threshold:
-      2021-01-01: 2
-    amount:
-      2021-01-01: 480
+values:
+  2021-01-01: 240

--- a/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent_care/dependent_cap.yaml
+++ b/openfisca_us/parameters/gov/states/ma/tax/income/credits/dependent_care/dependent_cap.yaml
@@ -1,0 +1,10 @@
+description: MA dependent care credit maximum number of qualifying individuals.
+metadata:
+  reference:
+    - title: Mass. General Laws c.62 § 6(x)
+      href: https://www.mass.gov/info-details/mass-general-laws-c62-ss-6#(x)-
+  unit: person
+  name: ma_dependent_care_credit_dependent_cap
+  label: MA dependent care credit dependent cap
+values:
+  2021-01-01: 2

--- a/openfisca_us/variables/gov/states/ma/tax/income/credits/ma_dependent_care_credit.py
+++ b/openfisca_us/variables/gov/states/ma/tax/income/credits/ma_dependent_care_credit.py
@@ -17,11 +17,12 @@ class ma_dependent_care_credit(Variable):
     def formula(tax_unit, period, parameters):
         # Expenses capped by number of qualifying individuals.
         expenses = tax_unit("tax_unit_childcare_expenses", period)
-        count_cdcc_eligible = tax_unit("count_cdcc_eligible", period)
         p = parameters(period).gov.states.ma.tax.income.credits.dependent_care
-        cap = p.amount.calc(count_cdcc_eligible)
+        count_cdcc_eligible = min_(
+            tax_unit("count_cdcc_eligible", period), p.dependent_cap
+        )
         # Line 1.
-        capped_expenses = min_(expenses, cap)
+        capped_expenses = min_(expenses, p.amount * count_cdcc_eligible)
         # Skip lines 2 and 3, which are done in intermediate steps.
         # Line 4: Smallest of lines 1, 2, 3.
         amount_if_eligible = min_(

--- a/openfisca_us/variables/gov/states/ma/tax/income/credits/ma_dependent_credit.py
+++ b/openfisca_us/variables/gov/states/ma/tax/income/credits/ma_dependent_credit.py
@@ -21,5 +21,5 @@ class ma_dependent_credit(Variable):
         disabled = person("is_disabled", period)
         eligible = dependent & (child | elderly | disabled)
         count_eligible = tax_unit.sum(eligible)
-        capped_eligible = min_(count_eligible, p.cap)
+        capped_eligible = min_(count_eligible, p.dependent_cap)
         return capped_eligible * p.amount


### PR DESCRIPTION
Fixes #1087

The scale parameter was closer to the law, but:
a) PolicyEngine doesn't display scale parameters
b) Several have proposed lifting the cap, which is simpler with a cap than scale parameter, even if we could display it

So I switched it to a cap/dependent structure.