### PR TITLE
Black package fix

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1162,3 +1162,7 @@
     added:
     - MD local income tax rates.
   date: 2022-07-16 11:16:19
+- bump: patch
+  changes:
+    fixed:
+    - Click dependency limited to >=8.0.0.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "synthimpute",
         "tables",
         "tqdm",
+        "click>=8.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
@rickecon (and anyone else who ran into this issue, output below), I think this fixes the contradictory dependency between `black` and `openfisca_us`.

```bash
autopep8 -r .
black . -l 79
Traceback (most recent call last):
  File "/Users/richardevans/opt/anaconda3/envs/openfisca-us-test/bin/black", line 5, in <module>
    from black import patched_main
  File "src/black/__init__.py", line 35, in <module>
ImportError: cannot import name 'ParameterSource' from 'click.core' (/Users/richardevans/opt/anaconda3/envs/openfisca-us-test/lib/python3.7/site-packages/click/core.py)
make: *** [format] Error 1
```