### PR TITLE
Add YAML tabs check

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Test that parameter files do not contain tabs with informative error messages.

--- a/openfisca_us/parameters/gov/states/in/tax/income/deductions/military_service/max.yaml
+++ b/openfisca_us/parameters/gov/states/in/tax/income/deductions/military_service/max.yaml
@@ -7,5 +7,5 @@ metadata:
   name: in_max_military_service_deduction
   label: IN max military service deduction
   reference:
-    - title: IC 6-3-2-4	Military service deduction; retirement income or survivor's benefits deduction (a)(1)
+    - title: IC 6-3-2-4 Military service deduction; retirement income or survivor's benefits deduction (a)(1)
       href: http://iga.in.gov/legislative/laws/2021/ic/titles/006#6-3-2-4

--- a/openfisca_us/tests/code_health/parameters.py
+++ b/openfisca_us/tests/code_health/parameters.py
@@ -1,0 +1,29 @@
+"""
+This module contains a test that iterates through all parameter files in the openfisca_us/parameters directory and asserts that none of them contain the '\t' character.
+"""
+
+from openfisca_us.model_api import REPO
+
+
+def test_parameter_files_do_not_contain_tabs():
+    """
+    This test iterates through all parameter files in the openfisca_us/parameters directory and asserts that none of them contain the '\t' character.
+    """
+    errors = []
+    for file_name in (REPO / "parameters").glob("**/*.yaml"):
+        with file_name.open() as file:
+            i = 0
+            for line in file:
+                i += 1
+                if "\t" in line:
+                    errors.append(
+                        f"\n\n{file_name.relative_to(REPO)} (line {i}):"
+                        + "'\\t' character found in line (shown below):\n\n"
+                        + line.replace("\t", "[TAB]")
+                    )
+
+    num_errors = len(errors)
+    assert num_errors == 0, (
+        f"\nFound {len(errors)} parameter file{'s' if len(errors) != 1 else ''} with tabs. Details below:"
+        + "\n".join(errors)
+    )


### PR DESCRIPTION
cc @MattHJensen - I just noticed that one of the IN parameters had a TAB character in it, which prevents the package from working on most Colab instances due to the version of YAML installed. Thought I'd just add a test for it, which prints the below message:

```console
E         Found 1 parameter file with tabs. Details below:
E         
E         parameters/gov/states/in/tax/income/deductions/military_service/max.yaml (line 10):'\t' character found in line (shown below):
E         
E             - title: IC 6-3-2-4[TAB]Military service deduction; retirement income or survivor's benefits deduction (a)(1)
```
