### PR TITLE
Fix qualified dividends bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - A bug causing qualified dividends to not be counted as 'net capital gain'.

--- a/openfisca_us/tests/policy/baseline/taxsim/misc/qualified_dividends.yaml
+++ b/openfisca_us/tests/policy/baseline/taxsim/misc/qualified_dividends.yaml
@@ -1,0 +1,36 @@
+# OpenFisca-US test file derived from f21.its.csv and f21.ota.csv files
+- name: Tax unit with taxsimid 5832 from f21.its.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 53
+        employment_income: 159000
+        qualified_dividend_income: 20000
+        taxable_interest_income: 3000
+        social_security: 20000
+        real_estate_taxes: 8000
+        interest_expense: 2000
+        ssi: 0
+        state_supplement: 0
+        wic: 0
+    spm_units:
+      spm_unit:
+        members: [person1]
+        snap: 0
+        tanf: 0
+    tax_units:
+      tax_unit:
+        members: [person1]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1]
+        state_code: TX
+  output:
+    taxsim_tfica: 11159.10
+    income_tax: 37091.00

--- a/openfisca_us/variables/gov/irs/tax/federal_income/capital_gains/net_capital_gain.py
+++ b/openfisca_us/variables/gov/irs/tax/federal_income/capital_gains/net_capital_gain.py
@@ -23,9 +23,7 @@ class net_capital_gain(Variable):
         net_capital_gains = max_(
             0, net_long_term_capital_gain - net_short_term_capital_loss
         )
-        qualified_dividends = tax_unit("qualified_dividend_income", period)
+        qualified_dividends = add(
+            tax_unit, period, ["qualified_dividend_income"]
+        )
         return net_capital_gains + qualified_dividends
-
-    formula = excess(
-        of="net_long_term_capital_gain", over="net_short_term_capital_loss"
-    )


### PR DESCRIPTION
Fixes #1220 . The issue was a bug in which `net_capital_gain` had multiple formulas, and the last one was incorrect. Removed.

cc @martinholmer (I've added your test case, which now passes).