### PR TITLE
Fix negative CTC in 2021

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Don't reduce CTC by more than the maximum in 2021.

--- a/openfisca_us/parameters/gov/irs/credits/residential_energy/nonbusiness/in_effect.yaml
+++ b/openfisca_us/parameters/gov/irs/credits/residential_energy/nonbusiness/in_effect.yaml
@@ -3,12 +3,10 @@ values:
   2006-01-01: true
   2008-01-01: false
   2009-01-01: true
-  2033-01-01: false
+  2022-01-01: false
 metadata:
   name: nonbusiness_energy_property_credit_in_effect
   label: Nonbusiness energy property tax credit in effect
   reference:
     - title: 26 U.S.C. § 25C(g)
       href: https://www.law.cornell.edu/uscode/text/26/25C#g
-    - title: Inflation Reduction Act, Part 3, Section 13301 (a)
-      href: https://www.democrats.senate.gov/imo/media/doc/inflation_reduction_act_of_2022.pdf#page=338

--- a/openfisca_us/parameters/gov/irs/credits/residential_energy/nonbusiness/in_effect.yaml
+++ b/openfisca_us/parameters/gov/irs/credits/residential_energy/nonbusiness/in_effect.yaml
@@ -3,10 +3,12 @@ values:
   2006-01-01: true
   2008-01-01: false
   2009-01-01: true
-  2022-01-01: false
+  2033-01-01: false
 metadata:
   name: nonbusiness_energy_property_credit_in_effect
   label: Nonbusiness energy property tax credit in effect
   reference:
     - title: 26 U.S.C. § 25C(g)
       href: https://www.law.cornell.edu/uscode/text/26/25C#g
+    - title: Inflation Reduction Act, Part 3, Section 13301 (a)
+      href: https://www.democrats.senate.gov/imo/media/doc/inflation_reduction_act_of_2022.pdf#page=338

--- a/openfisca_us/tests/policy/baseline/taxsim/misc/ctc.yaml
+++ b/openfisca_us/tests/policy/baseline/taxsim/misc/ctc.yaml
@@ -1,0 +1,41 @@
+# OpenFisca-US test file derived from m21.ita.csv and m21.ota.csv files
+# See https://github.com/PolicyEngine/openfisca-us/issues/1270
+- name: Tax unit with recid 95001 from m21.ita.csv
+  absolute_error_margin: 0.01
+  period: 2021
+  input:
+    people:
+      person1:
+        is_tax_unit_head: 1
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 0
+        age: 64
+        ssi: 0
+        state_supplement: 0
+        wic: 0
+        employment_income: 175000
+        taxable_interest_income: 100000
+      person2:
+        is_tax_unit_head: 0
+        is_tax_unit_spouse: 0
+        is_tax_unit_dependent: 1
+        age: 11
+        ssi: 0
+        state_supplement: 0
+        wic: 0
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+        snap: 0
+        tanf: 0
+    tax_units:
+      tax_unit:
+        members: [person1, person2]
+        premium_tax_credit: 0
+    households:
+      household:
+        members: [person1, person2]
+        state_code: TX
+  output:
+    taxsim_tfica: 11391.10
+    income_tax: 65615.00

--- a/openfisca_us/variables/gov/irs/credits/ctc/ctc_reduction.py
+++ b/openfisca_us/variables/gov/irs/credits/ctc/ctc_reduction.py
@@ -87,6 +87,6 @@ class ctc_reduction(Variable):
 
         arpa_reduction = min_(arpa_phase_out_max_reduction, arpa_reduction_max)
 
-        return original_phase_out + arpa_reduction
+        return min_(original_phase_out + arpa_reduction, maximum_ctc)
 
     formula_2022 = formula


### PR DESCRIPTION
Fixes #1270 

We may want to instead move the capping to the `ctc` variable, but I didn't look into other potential implications of that and this seemed to be the smallest deviation that fixes the reported issue.