### PR TITLE
Verify SSI computation for an ineligible parent with an eligible child

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+      - SSI integration test case.

--- a/openfisca_us/tests/policy/baseline/gov/ssa/ssi/integration.yaml
+++ b/openfisca_us/tests/policy/baseline/gov/ssa/ssi/integration.yaml
@@ -30,3 +30,21 @@
   output:
     ssi_countable_income: 116 * 12
     ssi: 678 * 12 # 794 - 116
+
+- name: Single parent of blind child with $2,000 monthly earnings.
+  period: 2022
+  input:
+    people:
+      parent:
+        age: 40
+        employment_income: 2_000 * 12
+      child:
+        age: 10
+        is_blind: true
+    tax_units:
+      tax_unit:
+        members: [parent, child]
+  output:
+    # This is what we currently produce ($744.50 * 12).
+    # TODO: Check what it should be by hand.
+    ssi: [0, 8_934]


### PR DESCRIPTION
Fixes #1301

Not yet complete - still need to compute it by hand to verify we're producing the correct result.

Here's the [computation tree](https://gist.github.com/MaxGhenis/377c736e54a6202075d44fdc1d2d51dd) for this test case.